### PR TITLE
Add theme selection to profile page

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,76 @@
+(function () {
+  const STORAGE_KEY = 'theme-preference';
+  const THEME_ATTR = 'data-bs-theme';
+
+  function getStoredPreference() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function storePreference(value) {
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch (_) {
+      // ignore storage errors
+    }
+  }
+
+  function getSystemPreference() {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  }
+
+  function getCurrentPreference() {
+    const stored = getStoredPreference();
+    if (stored === 'light' || stored === 'dark') return stored;
+    return 'system';
+  }
+
+  function applyTheme(theme) {
+    const resolved = theme === 'system' ? getSystemPreference() : theme;
+    document.documentElement.setAttribute(THEME_ATTR, resolved);
+  }
+
+  function initTheme() {
+    // Apply ASAP to avoid flash
+    applyTheme(getCurrentPreference());
+
+    // Listen to system changes if following system
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', () => {
+        if (getCurrentPreference() === 'system') applyTheme('system');
+      });
+    } else if (typeof media.addListener === 'function') {
+      media.addListener(() => {
+        if (getCurrentPreference() === 'system') applyTheme('system');
+      });
+    }
+
+    // Wire profile selector if present
+    const select = document.getElementById('themePreference');
+    if (select) {
+      select.value = getCurrentPreference();
+      select.addEventListener('change', () => {
+        const value = select.value;
+        if (value === 'light' || value === 'dark') {
+          storePreference(value);
+        } else {
+          // system
+          try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+        }
+        applyTheme(value);
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTheme);
+  } else {
+    initTheme();
+  }
+})();

--- a/templates/auth/profile.html
+++ b/templates/auth/profile.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='auth.css') }}">
     <link rel="icon" href="{{ url_for('static', filename='images/cei_logo.jpg') }}" type="image/jpeg">
+    <meta name="color-scheme" content="light dark">
+    <script src="{{ url_for('static', filename='theme.js') }}" defer></script>
 </head>
 <body>
     <!-- Navigation -->
@@ -178,6 +180,28 @@
                                 </button>
                             </div>
                         </form>
+                    </div>
+                </div>
+
+                <!-- Appearance / Theme -->
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">
+                            <i class="fas fa-circle-half-stroke me-2"></i>Appearance
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-6">
+                                <label for="themePreference" class="form-label">Theme</label>
+                                <select id="themePreference" class="form-select">
+                                    <option value="system">Match system</option>
+                                    <option value="light">Light</option>
+                                    <option value="dark">Dark</option>
+                                </select>
+                                <div class="form-text">Applies across the app on this device.</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/templates/dashboard/base_dashboard.html
+++ b/templates/dashboard/base_dashboard.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" href="{{ url_for('static', filename='images/lassie_favicon.svg') }}" type="image/svg+xml">
+    <meta name="color-scheme" content="light dark">
+    <script src="{{ url_for('static', filename='theme.js') }}" defer></script>
     {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" href="{{ url_for('static', filename='images/lassie_favicon.svg') }}" type="image/svg+xml">
+    <meta name="color-scheme" content="light dark">
+    <script src="{{ url_for('static', filename='theme.js') }}" defer></script>
     <style>
         .flash-message {
             margin-top: 1rem;

--- a/templates/index_authenticated.html
+++ b/templates/index_authenticated.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" href="{{ url_for('static', filename='images/cei_logo.jpg') }}" type="image/jpeg">
+    <meta name="color-scheme" content="light dark">
+    <script src="{{ url_for('static', filename='theme.js') }}" defer></script>
     <style>
         .flash-message {
             margin-top: 1rem;


### PR DESCRIPTION
Add a light/dark/system theme selector to the profile page and apply it globally, allowing users to choose their preferred display mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-c14f701c-509e-44b4-98b4-81db11fa95c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c14f701c-509e-44b4-98b4-81db11fa95c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

