### PR TITLE
feat: PLO trending with sparklines and drill-down charts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -219,14 +219,14 @@
         "filename": "demos/full_semester_manifest.json",
         "hashed_secret": "92aee6d7ab6ce7f96c3b775533a5012a7b040360",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 64
       },
       {
         "type": "Secret Keyword",
         "filename": "demos/full_semester_manifest.json",
         "hashed_secret": "ed66ac12466f00ab1547d9eff91e48cdf44bbfe3",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 73
       }
     ],
     "demos/full_semester_workflow.json": [
@@ -236,6 +236,15 @@
         "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
         "is_verified": false,
         "line_number": 37
+      }
+    ],
+    "demos/plo_dashboard_workflow.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "demos/plo_dashboard_workflow.json",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 43
       }
     ],
     "docs/decisions/EMAIL_SIMPLIFICATION_SUMMARY.md": [
@@ -311,6 +320,15 @@
         "hashed_secret": "afdb6128c4f0c124c8ffe0f2b8469b757c9996f2",
         "is_verified": false,
         "line_number": 15
+      }
+    ],
+    "docs/workflow-walkthroughs/plo_dashboard.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/workflow-walkthroughs/plo_dashboard.md",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 33
       }
     ],
     "research/CEI/archived/LEARNING_OUTCOMES_DEMO_2024-10-24.md": [
@@ -1134,5 +1152,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-26T17:31:20Z"
+  "generated_at": "2026-03-07T07:59:46Z"
 }

--- a/data/session/manager.py
+++ b/data/session/manager.py
@@ -114,6 +114,14 @@ class SessionService:
         session["remember_me"] = remember_me
         session["csrf_token"] = SessionSecurity.generate_csrf_token()
 
+        # Stamp the current database generation token so stale sessions
+        # can be detected after a database re-seed (--clear).
+        from src.services.auth_service import _read_db_generation
+
+        db_gen = _read_db_generation()
+        if db_gen is not None:
+            session["_db_generation"] = db_gen
+
         # Set session as permanent if remember me is enabled
         if remember_me:
             session.permanent = True

--- a/data/session/security.py
+++ b/data/session/security.py
@@ -8,7 +8,6 @@ session expiry checks, and other security-related session operations.
 import hashlib
 import secrets
 from datetime import datetime, timezone
-from typing import Optional
 
 from flask import request, session
 
@@ -26,7 +25,6 @@ logger = get_logger(__name__)
 class SessionSecurityError(Exception):
     """Raised when session security validation fails"""
 
-    pass
 
 
 class SessionSecurity:

--- a/demos/full_semester_manifest.json
+++ b/demos/full_semester_manifest.json
@@ -484,6 +484,19 @@
             ]
         },
         {
+            "course_code": "BIOL-201",
+            "term_code": "FA2023",
+            "_comment": "Stable course — offered every term",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 16,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
             "course_code": "ZOOL-101",
             "term_code": "FA2023",
             "sections": [
@@ -492,6 +505,19 @@
                     "enrollment": 22,
                     "status": "completed",
                     "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-205",
+            "term_code": "FA2023",
+            "_comment": "ZOOL stable offering — offered every term from inception",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 2
                 }
             ]
         },
@@ -560,6 +586,32 @@
                     "enrollment": 20,
                     "status": "completed",
                     "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-205",
+            "term_code": "SP2024",
+            "_comment": "ZOOL stable offering — offered every term",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-301",
+            "term_code": "SP2024",
+            "_comment": "Stable course — offered every term",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 15,
+                    "status": "completed",
+                    "instructor_idx": 3
                 }
             ]
         },
@@ -692,6 +744,71 @@
                     "enrollment": 18,
                     "status": "completed",
                     "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-101",
+            "term_code": "SP2025",
+            "_comment": "Stable course continues through restructuring",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 22,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-201",
+            "term_code": "SP2025",
+            "_comment": "Stable course continues through restructuring",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-301",
+            "term_code": "SP2025",
+            "_comment": "Stable course continues through restructuring",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 14,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-101",
+            "term_code": "SP2025",
+            "_comment": "ZOOL stable offering — consistent presence across terms",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 22,
+                    "status": "completed",
+                    "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-205",
+            "term_code": "SP2025",
+            "_comment": "ZOOL stable offering — consistent presence across terms",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 2
                 }
             ]
         },
@@ -1457,6 +1574,14 @@
         {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 14},
         {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 16},
 
+        {"_comment": "BIOL-201 FA2023 — moderate performance, early in improvement arc"},
+        {"term_code": "FA2023", "course_code": "BIOL-201", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 16, "students_passed": 11},
+        {"term_code": "FA2023", "course_code": "BIOL-201", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 16, "students_passed": 10},
+        {"term_code": "FA2023", "course_code": "BIOL-201", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 16, "students_passed": 12},
+        {"term_code": "FA2023", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 13},
+        {"term_code": "FA2023", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 12},
+        {"term_code": "FA2023", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 14},
+
         {"_comment": "BIOL-250 FA2023 — overloaded course, 5 CLOs, mediocre pass rates (first signs of trouble)"},
         {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 28, "students_passed": 18},
         {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 28, "students_passed": 17},
@@ -1481,6 +1606,12 @@
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 15},
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 20, "students_passed": 14},
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 20, "students_passed": 16},
+        {"term_code": "SP2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 15, "students_passed": 11},
+        {"term_code": "SP2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 15, "students_passed": 10},
+        {"term_code": "SP2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 15, "students_passed": 12},
+        {"term_code": "SP2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 13},
+        {"term_code": "SP2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 14},
 
         {"_comment": "BIOL-250 SP2024 — worsening (department starts discussing intervention)"},
         {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 30, "students_passed": 17},
@@ -1515,14 +1646,30 @@
         {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 26, "students_passed": 10},
         {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 5, "status": "approved", "students_took": 26, "students_passed": 9},
 
-        {"_comment": "=== SP2025 — First semester post-split (BIOL-251 + BIOL-252 debut) ==="},
-        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 15},
-        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 16},
-        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 14},
-        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 12},
-        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 11},
-        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 10},
-        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 18, "students_passed": 11}
+        {"_comment": "=== SP2025 — Post-restructure: stable courses continue improving + split courses debut with strong results ==="},
+        {"term_code": "SP2025", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 19},
+        {"term_code": "SP2025", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 18},
+        {"term_code": "SP2025", "course_code": "BIOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 20},
+        {"term_code": "SP2025", "course_code": "BIOL-201", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 16},
+        {"term_code": "SP2025", "course_code": "BIOL-201", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 15},
+        {"term_code": "SP2025", "course_code": "BIOL-201", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 16},
+        {"term_code": "SP2025", "course_code": "BIOL-301", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 14, "students_passed": 12},
+        {"term_code": "SP2025", "course_code": "BIOL-301", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 14, "students_passed": 11},
+        {"term_code": "SP2025", "course_code": "BIOL-301", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 14, "students_passed": 13},
+        {"_comment": "BIOL-251/252 debut — focused curriculum yields much better results than overloaded BIOL-250"},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 19},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 18},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 17},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 15},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 15},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2025", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 19},
+        {"term_code": "SP2025", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 17},
+        {"term_code": "SP2025", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 19},
+        {"term_code": "SP2025", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 16},
+        {"term_code": "SP2025", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2025", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 15}
     ],
     "program_outcomes": {
         "_comment": "Per-program PLO definitions + CLO mappings. The seeder creates PLOs, opens a draft mapping, links the CLOs listed under clo_mappings, then publishes the draft as mapping version 1. assessment_display_mode controls how the PLO dashboard badge renders (binary = S/U, percentage = 78%, both = S (78%)). plo_number is an integer (stored in program_outcomes.plo_number INTEGER) — the UI renders it as 'PLO-<n>'.",

--- a/demos/full_semester_manifest.json
+++ b/demos/full_semester_manifest.json
@@ -123,6 +123,27 @@
             "credits": 3
         },
         {
+            "program_code": "BIOL",
+            "code": "BIOL-250",
+            "name": "Molecular Biology & Genetics",
+            "credits": 4,
+            "_comment": "Overloaded 4cr course covering 5 PLOs — retired after FA2024, split into BIOL-251 + BIOL-252"
+        },
+        {
+            "program_code": "BIOL",
+            "code": "BIOL-251",
+            "name": "Cell & Molecular Biology",
+            "credits": 2,
+            "_comment": "Post-split from BIOL-250, covers PLOs 2 and 5 — first offered SP2025"
+        },
+        {
+            "program_code": "BIOL",
+            "code": "BIOL-252",
+            "name": "Genetics & Inheritance",
+            "credits": 2,
+            "_comment": "Post-split from BIOL-250, covers PLOs 1, 6, 7 — first offered SP2025"
+        },
+        {
             "program_code": "ZOOL",
             "code": "ZOOL-101",
             "name": "Animal Diversity",
@@ -282,6 +303,92 @@
             "students_passed": 15,
             "assessment_tool": "Research Grant"
         },
+
+        {"_comment": "=== BIOL-250 specific CLOs 4-5 (template gives 1-3, these are additional for the overloaded course) ==="},
+        {
+            "course_code": "BIOL-250",
+            "clo_number": 4,
+            "description": "Interpret patterns of genetic inheritance and gene expression",
+            "assessment_method": "Written Exam",
+            "status": "assigned"
+        },
+        {
+            "course_code": "BIOL-250",
+            "clo_number": 5,
+            "description": "Demonstrate proficiency in molecular laboratory techniques",
+            "assessment_method": "Lab Report",
+            "status": "assigned"
+        },
+
+        {"_comment": "=== BIOL-251 CLOs 1-3 (FA2025, approved — Dr. Morgan, post-split success story) ==="},
+        {
+            "course_code": "BIOL-251",
+            "clo_number": 1,
+            "status": "approved",
+            "submitted_at": "2025-12-10T14:00:00",
+            "students_took": 20,
+            "students_passed": 17,
+            "assessment_tool": "Molecular Methods Lab"
+        },
+        {
+            "course_code": "BIOL-251",
+            "clo_number": 2,
+            "status": "approved",
+            "submitted_at": "2025-12-10T14:00:00",
+            "students_took": 20,
+            "students_passed": 18,
+            "assessment_tool": "Cell Biology Analysis"
+        },
+        {
+            "course_code": "BIOL-251",
+            "clo_number": 3,
+            "status": "approved",
+            "submitted_at": "2025-12-10T14:00:00",
+            "students_took": 20,
+            "students_passed": 16,
+            "assessment_tool": "Systems Integration Project"
+        },
+
+        {"_comment": "=== BIOL-252 CLOs 1-4 (FA2025, approved — Prof. Chen, genetics focus after split) ==="},
+        {
+            "course_code": "BIOL-252",
+            "clo_number": 1,
+            "status": "approved",
+            "submitted_at": "2025-12-15T10:00:00",
+            "students_took": 16,
+            "students_passed": 13,
+            "assessment_tool": "Genetics Lab Design"
+        },
+        {
+            "course_code": "BIOL-252",
+            "clo_number": 2,
+            "status": "approved",
+            "submitted_at": "2025-12-15T10:00:00",
+            "students_took": 16,
+            "students_passed": 12,
+            "assessment_tool": "Inheritance Pattern Analysis"
+        },
+        {
+            "course_code": "BIOL-252",
+            "clo_number": 3,
+            "status": "approved",
+            "submitted_at": "2025-12-15T10:00:00",
+            "students_took": 16,
+            "students_passed": 11,
+            "assessment_tool": "Ecosystem Genetics Report"
+        },
+        {
+            "course_code": "BIOL-252",
+            "clo_number": 4,
+            "description": "Perform quantitative laboratory analyses in genetics",
+            "assessment_method": "Lab Report",
+            "status": "approved",
+            "submitted_at": "2025-12-15T10:00:00",
+            "students_took": 16,
+            "students_passed": 13,
+            "assessment_tool": "Genetics Lab Practical"
+        },
+
         {
             "_comment": "ZOOL-101 CLOs 1-3 - All approved (Dr. Patel completed this one early Dec 8)",
             "course_code": "ZOOL-101",
@@ -389,6 +496,32 @@
             ]
         },
         {
+            "course_code": "BIOL-250",
+            "term_code": "FA2023",
+            "_comment": "Overloaded 4cr course — first term of decline",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 28,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-301",
+            "term_code": "FA2023",
+            "_comment": "301 also struggling with genetic analysis burden",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 14,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
             "course_code": "BIOL-101",
             "term_code": "SP2024",
             "sections": [
@@ -427,6 +560,19 @@
                     "enrollment": 20,
                     "status": "completed",
                     "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-250",
+            "term_code": "SP2024",
+            "_comment": "Continued decline — department noticing the trend",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 30,
+                    "status": "completed",
+                    "instructor_idx": 3
                 }
             ]
         },
@@ -485,6 +631,19 @@
             ]
         },
         {
+            "course_code": "BIOL-250",
+            "term_code": "FA2024",
+            "_comment": "Final semester before split — worst performance yet, triggers curriculum redesign",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 26,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
             "course_code": "ZOOL-205",
             "term_code": "FA2024",
             "sections": [
@@ -507,6 +666,32 @@
                     "section_number": "001",
                     "enrollment": 42,
                     "status": "completed"
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-251",
+            "term_code": "SP2025",
+            "_comment": "First semester post-split — initial improvement visible",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 22,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-252",
+            "term_code": "SP2025",
+            "_comment": "First semester post-split — initial improvement visible",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 3
                 }
             ]
         },
@@ -561,6 +746,32 @@
                 {
                     "section_number": "001",
                     "enrollment": 18,
+                    "status": "assigned",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-251",
+            "term_code": "FA2025",
+            "_comment": "Second semester post-split — continued improvement",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 20,
+                    "status": "assigned",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-252",
+            "term_code": "FA2025",
+            "_comment": "Second semester post-split — strong improvement",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 16,
                     "status": "assigned",
                     "instructor_idx": 3
                 }
@@ -1156,6 +1367,87 @@
             ]
         },
 
+        {"_comment": "=== BIOL-251 FA2025 section outcome overrides (current term, post-split improvement) ==="},
+        {
+            "course_code": "BIOL-251",
+            "section_number": "001",
+            "clo_number": 1,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -12},
+                {"event": "Approved", "relative_days": -10}
+            ]
+        },
+        {
+            "course_code": "BIOL-251",
+            "section_number": "001",
+            "clo_number": 2,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -12},
+                {"event": "Approved", "relative_days": -10}
+            ]
+        },
+        {
+            "course_code": "BIOL-251",
+            "section_number": "001",
+            "clo_number": 3,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -12},
+                {"event": "Approved", "relative_days": -10}
+            ]
+        },
+
+        {"_comment": "=== BIOL-252 FA2025 section outcome overrides (current term, genetics focus) ==="},
+        {
+            "course_code": "BIOL-252",
+            "section_number": "001",
+            "clo_number": 1,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -8},
+                {"event": "Approved", "relative_days": -5}
+            ]
+        },
+        {
+            "course_code": "BIOL-252",
+            "section_number": "001",
+            "clo_number": 2,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -8},
+                {"event": "Approved", "relative_days": -5}
+            ]
+        },
+        {
+            "course_code": "BIOL-252",
+            "section_number": "001",
+            "clo_number": 3,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -8},
+                {"event": "Approved", "relative_days": -5}
+            ]
+        },
+        {
+            "course_code": "BIOL-252",
+            "section_number": "001",
+            "clo_number": 4,
+            "status": "approved",
+            "history": [
+                {"event": "Assigned", "relative_days": -45},
+                {"event": "Submitted", "relative_days": -8},
+                {"event": "Approved", "relative_days": -5}
+            ]
+        },
+
         {"_comment": "=== HISTORICAL TERM OVERRIDES (for trend data, improving pass rates FA2023→FA2024) ==="},
 
         {"term_code": "FA2023", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 14},
@@ -1164,6 +1456,18 @@
         {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 15},
         {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 14},
         {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 16},
+
+        {"_comment": "BIOL-250 FA2023 — overloaded course, 5 CLOs, mediocre pass rates (first signs of trouble)"},
+        {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 28, "students_passed": 18},
+        {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 28, "students_passed": 17},
+        {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 28, "students_passed": 16},
+        {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 28, "students_passed": 15},
+        {"term_code": "FA2023", "course_code": "BIOL-250", "section_number": "001", "clo_number": 5, "status": "approved", "students_took": 28, "students_passed": 14},
+
+        {"_comment": "BIOL-301 FA2023 — also struggling, especially CLO 2 (genetic analysis = PLO 6)"},
+        {"term_code": "FA2023", "course_code": "BIOL-301", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 14, "students_passed": 11},
+        {"term_code": "FA2023", "course_code": "BIOL-301", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 14, "students_passed": 9},
+        {"term_code": "FA2023", "course_code": "BIOL-301", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 14, "students_passed": 12},
 
         {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 24, "students_passed": 18},
         {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 24, "students_passed": 17},
@@ -1177,6 +1481,13 @@
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 15},
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 20, "students_passed": 14},
         {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 20, "students_passed": 16},
+
+        {"_comment": "BIOL-250 SP2024 — worsening (department starts discussing intervention)"},
+        {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 30, "students_passed": 17},
+        {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 30, "students_passed": 16},
+        {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 30, "students_passed": 14},
+        {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 30, "students_passed": 13},
+        {"term_code": "SP2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 5, "status": "approved", "students_took": 30, "students_passed": 12},
 
         {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 25, "students_passed": 21},
         {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 25, "students_passed": 20},
@@ -1195,7 +1506,23 @@
         {"term_code": "FA2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 24, "students_passed": 21},
         {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 19, "students_passed": 16},
         {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 19, "students_passed": 14},
-        {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 19, "students_passed": 15}
+        {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 19, "students_passed": 15},
+
+        {"_comment": "BIOL-250 FA2024 — worst semester, triggers curriculum redesign (35-54% pass rates)"},
+        {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 26, "students_passed": 14},
+        {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 26, "students_passed": 12},
+        {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 26, "students_passed": 11},
+        {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 26, "students_passed": 10},
+        {"term_code": "FA2024", "course_code": "BIOL-250", "section_number": "001", "clo_number": 5, "status": "approved", "students_took": 26, "students_passed": 9},
+
+        {"_comment": "=== SP2025 — First semester post-split (BIOL-251 + BIOL-252 debut) ==="},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 15},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 16},
+        {"term_code": "SP2025", "course_code": "BIOL-251", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 14},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 12},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 11},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 10},
+        {"term_code": "SP2025", "course_code": "BIOL-252", "section_number": "001", "clo_number": 4, "status": "approved", "students_took": 18, "students_passed": 11}
     ],
     "program_outcomes": {
         "_comment": "Per-program PLO definitions + CLO mappings. The seeder creates PLOs, opens a draft mapping, links the CLOs listed under clo_mappings, then publishes the draft as mapping version 1. assessment_display_mode controls how the PLO dashboard badge renders (binary = S/U, percentage = 78%, both = S (78%)). plo_number is an integer (stored in program_outcomes.plo_number INTEGER) — the UI renders it as 'PLO-<n>'.",
@@ -1208,7 +1535,9 @@
                     "clo_mappings": [
                         {"course_code": "BIOL-101", "clo_number": 1},
                         {"course_code": "BIOL-201", "clo_number": 1},
-                        {"course_code": "BIOL-301", "clo_number": 1}
+                        {"course_code": "BIOL-301", "clo_number": 1},
+                        {"course_code": "BIOL-250", "clo_number": 1},
+                        {"course_code": "BIOL-252", "clo_number": 1}
                     ]
                 },
                 {
@@ -1217,7 +1546,9 @@
                     "clo_mappings": [
                         {"course_code": "BIOL-101", "clo_number": 2},
                         {"course_code": "BIOL-201", "clo_number": 2},
-                        {"course_code": "BIOL-301", "clo_number": 2}
+                        {"course_code": "BIOL-301", "clo_number": 2},
+                        {"course_code": "BIOL-250", "clo_number": 2},
+                        {"course_code": "BIOL-251", "clo_number": 2}
                     ]
                 },
                 {
@@ -1233,6 +1564,33 @@
                     "description": "Students will demonstrate ethical reasoning in biological research contexts.",
                     "_comment": "Intentionally unmapped — demonstrates the 'no CLOs mapped yet' empty state in the PLO dashboard.",
                     "clo_mappings": []
+                },
+                {
+                    "plo_number": 5,
+                    "description": "Students will analyze molecular structure-function relationships in biological systems.",
+                    "_comment": "Covered by retired BIOL-250 CLO 3 (historical) and BIOL-251 CLO 3 (post-split). Shows decline→improvement arc.",
+                    "clo_mappings": [
+                        {"course_code": "BIOL-250", "clo_number": 3},
+                        {"course_code": "BIOL-251", "clo_number": 3}
+                    ]
+                },
+                {
+                    "plo_number": 6,
+                    "description": "Students will apply genetic analysis techniques to interpret inheritance patterns.",
+                    "_comment": "Previously covered by overloaded BIOL-250 CLO 4. Post-split: BIOL-252 CLO 2 takes primary responsibility.",
+                    "clo_mappings": [
+                        {"course_code": "BIOL-250", "clo_number": 4},
+                        {"course_code": "BIOL-252", "clo_number": 2}
+                    ]
+                },
+                {
+                    "plo_number": 7,
+                    "description": "Students will demonstrate proficiency in biological laboratory techniques and quantitative data analysis.",
+                    "_comment": "Covered by retired BIOL-250 CLO 5 (historical) and BIOL-252 CLO 4 (post-split).",
+                    "clo_mappings": [
+                        {"course_code": "BIOL-250", "clo_number": 5},
+                        {"course_code": "BIOL-252", "clo_number": 4}
+                    ]
                 }
             ]
         },

--- a/demos/full_semester_manifest.json
+++ b/demos/full_semester_manifest.json
@@ -10,6 +10,27 @@
     ],
     "terms": [
         {
+            "name": "Fall 2023",
+            "term_code": "FA2023",
+            "start_date": "2023-08-28",
+            "end_date": "2023-12-15",
+            "active": false
+        },
+        {
+            "name": "Spring 2024",
+            "term_code": "SP2024",
+            "start_date": "2024-01-10",
+            "end_date": "2024-05-15",
+            "active": false
+        },
+        {
+            "name": "Fall 2024",
+            "term_code": "FA2024",
+            "start_date": "2024-08-28",
+            "end_date": "2024-12-15",
+            "active": false
+        },
+        {
             "name": "Spring 2025",
             "term_code": "SP2025",
             "start_date": "2025-01-10",
@@ -341,6 +362,143 @@
         }
     ],
     "offerings": [
+        {
+            "_comment": "=== HISTORICAL TERMS (for trend data) ===",
+
+            "course_code": "BIOL-101",
+            "term_code": "FA2023",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 20,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-101",
+            "term_code": "FA2023",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 22,
+                    "status": "completed",
+                    "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-101",
+            "term_code": "SP2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 24,
+                    "status": "completed",
+                    "instructor_idx": 2
+                },
+                {
+                    "section_number": "002",
+                    "enrollment": 22,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-201",
+            "term_code": "SP2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 18,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-101",
+            "term_code": "SP2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 20,
+                    "status": "completed",
+                    "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-101",
+            "term_code": "FA2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 25,
+                    "status": "completed",
+                    "instructor_idx": 2
+                },
+                {
+                    "section_number": "002",
+                    "enrollment": 23,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-201",
+            "term_code": "FA2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 20,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+        {
+            "course_code": "BIOL-301",
+            "term_code": "FA2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 16,
+                    "status": "completed",
+                    "instructor_idx": 3
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-101",
+            "term_code": "FA2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 24,
+                    "status": "completed",
+                    "instructor_idx": 4
+                }
+            ]
+        },
+        {
+            "course_code": "ZOOL-205",
+            "term_code": "FA2024",
+            "sections": [
+                {
+                    "section_number": "001",
+                    "enrollment": 19,
+                    "status": "completed",
+                    "instructor_idx": 2
+                }
+            ]
+        },
+
+        {"_comment": "=== EXISTING TERMS (SP2025, FA2025) ==="},
+
         {
             "course_code": "HIST-101",
             "term_code": "SP2025",
@@ -996,7 +1154,48 @@
                     "relative_days": -7
                 }
             ]
-        }
+        },
+
+        {"_comment": "=== HISTORICAL TERM OVERRIDES (for trend data, improving pass rates FA2023→FA2024) ==="},
+
+        {"term_code": "FA2023", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 14},
+        {"term_code": "FA2023", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 20, "students_passed": 13},
+        {"term_code": "FA2023", "course_code": "BIOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 20, "students_passed": 15},
+        {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 15},
+        {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 14},
+        {"term_code": "FA2023", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 16},
+
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 24, "students_passed": 18},
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 24, "students_passed": 17},
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 24, "students_passed": 19},
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 1, "status": "approved", "students_took": 22, "students_passed": 16},
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 2, "status": "approved", "students_took": 22, "students_passed": 15},
+        {"term_code": "SP2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 3, "status": "approved", "students_took": 22, "students_passed": 17},
+        {"term_code": "SP2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 18, "students_passed": 13},
+        {"term_code": "SP2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 18, "students_passed": 14},
+        {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 15},
+        {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 20, "students_passed": 14},
+        {"term_code": "SP2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 20, "students_passed": 16},
+
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 25, "students_passed": 21},
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 25, "students_passed": 20},
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 25, "students_passed": 22},
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 1, "status": "approved", "students_took": 23, "students_passed": 19},
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 2, "status": "approved", "students_took": 23, "students_passed": 18},
+        {"term_code": "FA2024", "course_code": "BIOL-101", "section_number": "002", "clo_number": 3, "status": "approved", "students_took": 23, "students_passed": 20},
+        {"term_code": "FA2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 20, "students_passed": 17},
+        {"term_code": "FA2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 20, "students_passed": 16},
+        {"term_code": "FA2024", "course_code": "BIOL-201", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 20, "students_passed": 17},
+        {"term_code": "FA2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 16, "students_passed": 13},
+        {"term_code": "FA2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 16, "students_passed": 12},
+        {"term_code": "FA2024", "course_code": "BIOL-301", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 16, "students_passed": 14},
+        {"term_code": "FA2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 24, "students_passed": 20},
+        {"term_code": "FA2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 24, "students_passed": 18},
+        {"term_code": "FA2024", "course_code": "ZOOL-101", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 24, "students_passed": 21},
+        {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 1, "status": "approved", "students_took": 19, "students_passed": 16},
+        {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 2, "status": "approved", "students_took": 19, "students_passed": 14},
+        {"term_code": "FA2024", "course_code": "ZOOL-205", "section_number": "001", "clo_number": 3, "status": "approved", "students_took": 19, "students_passed": 15}
     ],
     "program_outcomes": {
         "_comment": "Per-program PLO definitions + CLO mappings. The seeder creates PLOs, opens a draft mapping, links the CLOs listed under clo_mappings, then publishes the draft as mapping version 1. assessment_display_mode controls how the PLO dashboard badge renders (binary = S/U, percentage = 78%, both = S (78%)). plo_number is an integer (stored in program_outcomes.plo_number INTEGER) — the UI renders it as 'PLO-<n>'.",

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -747,7 +747,6 @@ class DemoRunner:
         """Collect logs for this step (screenshots removed - not needed)."""
         # Artifacts are now just for tracking purposes in JSON
         # Actual log files are written by the application itself
-        pass
 
     def run_command(self, cmd: str, label: str = "Command") -> bool:
         """Run a shell command and return success status."""

--- a/docs/workflow-walkthroughs/scripts/run_demo.py
+++ b/docs/workflow-walkthroughs/scripts/run_demo.py
@@ -188,7 +188,7 @@ def _run_setup(commands: List[str], *, skip: bool, auto: bool) -> bool:
         # shell=True is intentional: setup blocks use &&, source, etc.
         # Commands come from a repo-controlled markdown file.
         rc = subprocess.run(  # nosec B602
-            cmd, shell=True, cwd=_REPO_ROOT
+            cmd, shell=True, cwd=_REPO_ROOT  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         ).returncode
         if rc != 0:
             print(f"\n✗ Setup command failed (exit {rc}): {cmd}\n")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,7 @@ pytest-xdist>=3.6.1        # Parallel test execution (35% faster)
 # Security scanning
 bandit>=1.7.5              # Security linter for Python
 safety>=2.3.0,<3.7.0       # Cap: 3.7.0 pulls typer 0.24+ which crashes on Python 3.11 (click.Choice not subscriptable)
+typer>=0.16.0,<0.24.0       # Cap: 0.24.0 uses click.Choice[T] which is not subscriptable on Python 3.11
 detect-secrets>=1.4.0        # Secret detection in code
 
 # Code quality and complexity

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,9 +20,8 @@ pytest-xdist>=3.6.1        # Parallel test execution (35% faster)
 
 # Security scanning
 bandit>=1.7.5              # Security linter for Python
-safety>=2.3.0              # Dependency vulnerability scanner
+safety>=2.3.0,<3.7.0       # Cap: 3.7.0 pulls typer 0.24+ which crashes on Python 3.11 (click.Choice not subscriptable)
 detect-secrets>=1.4.0        # Secret detection in code
-click>=8.2.0               # Required by typer>=0.15 (safety dep) for subscriptable Choice
 
 # Code quality and complexity
 radon>=6.0.1               # Code complexity analysis

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1836,6 +1836,19 @@ def _clear_flask_sessions() -> None:
         print(f"  🗑️  Cleared {cleared} session file(s)")
 
 
+def _rotate_db_generation() -> None:
+    """Write a new database generation token to invalidate stale sessions.
+
+    Any browser session whose stored ``_db_generation`` doesn't match the new
+    token will be destroyed on the next request, forcing a clean re-login.
+    See ``auth_service._get_session_user()`` for the check.
+    """
+    from src.services.auth_service import write_db_generation
+
+    token = write_db_generation()
+    print(f"  🔑 Rotated database generation token: {token[:8]}…")
+
+
 def _execute_seeding(args: argparse.Namespace) -> bool:
     """Execute the seeding operation."""
     if args.demo:
@@ -1846,6 +1859,7 @@ def _execute_seeding(args: argparse.Namespace) -> bool:
 
             reset_database()
             _clear_flask_sessions()
+            _rotate_db_generation()
         return demo_seeder.seed_demo()
     else:
         baseline_seeder = BaselineTestSeeder()
@@ -1855,6 +1869,7 @@ def _execute_seeding(args: argparse.Namespace) -> bool:
 
             reset_database()
             _clear_flask_sessions()
+            _rotate_db_generation()
 
         # Load manifest if provided
         manifest_data = None

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1348,8 +1348,20 @@ class DemoSeeder(BaselineSeeder):
             # Resolve optional term_code → term_id for disambiguation
             term_id = None
             term_code = override.get("term_code")
-            if term_code and term_map:
+            if term_code:
+                if not term_map:
+                    self.log(
+                        f"   ⚠️ term_code '{term_code}' provided but no term_map available; "
+                        f"skipping override for {course_code} Sec {section_number} CLO {clo_number}"
+                    )
+                    continue
                 term_id = term_map.get(term_code)
+                if term_id is None:
+                    self.log(
+                        f"   ⚠️ Unknown term_code '{term_code}'; "
+                        f"skipping override for {course_code} Sec {section_number} CLO {clo_number}"
+                    )
+                    continue
 
             # Skip if required fields are missing
             if not course_code or not section_number:
@@ -1584,18 +1596,7 @@ class DemoSeeder(BaselineSeeder):
         institution_id: str,
         term_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Find a specific section outcome by course/section/CLO number.
-
-        Args:
-            course_code: e.g. "BIOL-101"
-            section_number: e.g. "001"
-            clo_number: e.g. "1"
-            institution_id: Institution scope
-            term_id: Optional term filter — when provided, only sections
-                     belonging to offerings in that term are considered.
-                     Required when the same course+section exists in
-                     multiple terms (historical data).
-        """
+        """Find a specific section outcome by course/section/CLO number."""
         # Step 1: Find the course by course_code
         course = database_service.db.get_course_by_number(course_code, institution_id)
         if not course:
@@ -1605,37 +1606,12 @@ class DemoSeeder(BaselineSeeder):
             return None
 
         # Step 2: Find the course outcome (template) by clo_number
-        course_outcomes = database_service.db.get_course_outcomes(course_id)
-        outcome_template = None
-        for co in course_outcomes or []:
-            if str(co.get("clo_number")) == clo_number:
-                outcome_template = co
-                break
-        if not outcome_template:
-            return None
-        outcome_id = outcome_template.get("id") or outcome_template.get("outcome_id")
+        outcome_id = self._find_outcome_id(course_id, clo_number)
         if not outcome_id:
             return None
 
         # Step 3: Find the section by section_number (optionally filtered by term)
-        sections = database_service.db.get_sections_by_course(course_id)
-        target_section = None
-        for sec in sections or []:
-            if sec.get("section_number") != section_number:
-                continue
-            # When term_id is given, only match sections whose offering
-            # belongs to that term.
-            if term_id:
-                offering_id = sec.get("offering_id")
-                if offering_id:
-                    offering = database_service.db.get_course_offering(offering_id)
-                    if offering and offering.get("term_id") != term_id:
-                        continue
-            target_section = sec
-            break
-        if not target_section:
-            return None
-        section_id = target_section.get("id") or target_section.get("section_id")
+        section_id = self._find_section_id(course_id, section_number, term_id)
         if not section_id:
             return None
 
@@ -1646,6 +1622,51 @@ class DemoSeeder(BaselineSeeder):
             )
         )
         return section_outcome
+
+    def _find_outcome_id(self, course_id: str, clo_number: str) -> Optional[str]:
+        """Find the outcome template id by CLO number."""
+        course_outcomes = database_service.db.get_course_outcomes(course_id)
+        for co in course_outcomes or []:
+            if str(co.get("clo_number")) == clo_number:
+                return co.get("id") or co.get("outcome_id")
+        return None
+
+    def _find_section_id(
+        self,
+        course_id: str,
+        section_number: str,
+        term_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Find section id by section number, optionally filtering by term.
+
+        Caches offering lookups to avoid N+1 queries.
+        """
+        sections = database_service.db.get_sections_by_course(course_id)
+        offering_term_cache: dict = {}
+        for sec in sections or []:
+            if sec.get("section_number") != section_number:
+                continue
+            if term_id and not self._section_matches_term(
+                sec, term_id, offering_term_cache
+            ):
+                continue
+            return sec.get("id") or sec.get("section_id")
+        return None
+
+    @staticmethod
+    def _section_matches_term(
+        sec: Dict[str, Any],
+        term_id: str,
+        offering_cache: dict,
+    ) -> bool:
+        """Check if a section belongs to the given term (with caching)."""
+        offering_id = sec.get("offering_id")
+        if not offering_id:
+            return False
+        if offering_id not in offering_cache:
+            offering = database_service.db.get_course_offering(offering_id)
+            offering_cache[offering_id] = offering.get("term_id") if offering else None
+        return offering_cache[offering_id] == term_id
 
     def print_summary(self) -> None:
         """Print demo seeding summary"""

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1278,7 +1278,7 @@ class DemoSeeder(BaselineSeeder):
         if "section_outcome_overrides" in manifest:
             self.log("🔧 Applying section-specific CLO overrides...")
             override_count = self.apply_section_outcome_overrides(
-                manifest["section_outcome_overrides"], inst_ids[0]
+                manifest["section_outcome_overrides"], inst_ids[0], term_map
             )
             self.log(f"   ✅ Applied {override_count} section outcome overrides")
 
@@ -1302,7 +1302,10 @@ class DemoSeeder(BaselineSeeder):
         return True
 
     def apply_section_outcome_overrides(
-        self, overrides: List[Dict[str, Any]], institution_id: str
+        self,
+        overrides: List[Dict[str, Any]],
+        institution_id: str,
+        term_map: Optional[Dict[str, str]] = None,
     ) -> int:
         """
         Apply section-specific CLO status overrides after seeding.
@@ -1312,8 +1315,12 @@ class DemoSeeder(BaselineSeeder):
 
         Args:
             overrides: List of override dicts with course_code, section_number,
-                      clo_number, and the updates to apply
+                      clo_number, and the updates to apply.  Optional term_code
+                      disambiguates when the same course/section exists in
+                      multiple terms.
             institution_id: Institution ID to look up course/section
+            term_map: Optional mapping of term_code → term_id for
+                      term-specific override resolution
 
         Returns:
             Number of overrides successfully applied
@@ -1329,13 +1336,19 @@ class DemoSeeder(BaselineSeeder):
             clo_number = str(override.get("clo_number"))
             new_status = override.get("status", "assigned")
 
+            # Resolve optional term_code → term_id for disambiguation
+            term_id = None
+            term_code = override.get("term_code")
+            if term_code and term_map:
+                term_id = term_map.get(term_code)
+
             # Skip if required fields are missing
             if not course_code or not section_number:
                 continue
 
             # Look up the section outcome to update
             section_outcome = self._find_section_outcome(
-                course_code, section_number, clo_number, institution_id
+                course_code, section_number, clo_number, institution_id, term_id
             )
             if not section_outcome:
                 self.log(
@@ -1560,8 +1573,20 @@ class DemoSeeder(BaselineSeeder):
         section_number: str,
         clo_number: str,
         institution_id: str,
+        term_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Find a specific section outcome by course/section/CLO number."""
+        """Find a specific section outcome by course/section/CLO number.
+
+        Args:
+            course_code: e.g. "BIOL-101"
+            section_number: e.g. "001"
+            clo_number: e.g. "1"
+            institution_id: Institution scope
+            term_id: Optional term filter — when provided, only sections
+                     belonging to offerings in that term are considered.
+                     Required when the same course+section exists in
+                     multiple terms (historical data).
+        """
         # Step 1: Find the course by course_code
         course = database_service.db.get_course_by_number(course_code, institution_id)
         if not course:
@@ -1583,13 +1608,22 @@ class DemoSeeder(BaselineSeeder):
         if not outcome_id:
             return None
 
-        # Step 3: Find the section by section_number
+        # Step 3: Find the section by section_number (optionally filtered by term)
         sections = database_service.db.get_sections_by_course(course_id)
         target_section = None
         for sec in sections or []:
-            if sec.get("section_number") == section_number:
-                target_section = sec
-                break
+            if sec.get("section_number") != section_number:
+                continue
+            # When term_id is given, only match sections whose offering
+            # belongs to that term.
+            if term_id:
+                offering_id = sec.get("offering_id")
+                if offering_id:
+                    offering = database_service.db.get_course_offering(offering_id)
+                    if offering and offering.get("term_id") != term_id:
+                        continue
+            target_section = sec
+            break
         if not target_section:
             return None
         section_id = target_section.get("id") or target_section.get("section_id")

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1807,6 +1807,35 @@ def _confirm_deployed_environment(args: argparse.Namespace, database_url: str) -
     print("\n✅ Confirmation received. Proceeding with remote seeding...\n")
 
 
+def _clear_flask_sessions() -> None:
+    """Clear Flask server-side session files to force re-login after DB reset.
+
+    Flask-Session stores sessions as files in ``flask_session/`` (the default
+    ``SESSION_FILE_DIR``).  When the database is wiped the user rows disappear
+    but stale session files keep browsers "logged in", which is confusing.
+    Removing these files ensures every user must authenticate again.
+    """
+    import glob
+
+    session_dirs = [
+        os.path.join(project_root, "flask_session"),
+        os.path.join(project_root, "data", "flask_session"),
+    ]
+
+    cleared = 0
+    for session_dir in session_dirs:
+        if os.path.isdir(session_dir):
+            files = glob.glob(os.path.join(session_dir, "*"))
+            cleared += len(files)
+            for f in files:
+                try:
+                    os.remove(f)
+                except OSError:
+                    pass
+    if cleared:
+        print(f"  🗑️  Cleared {cleared} session file(s)")
+
+
 def _execute_seeding(args: argparse.Namespace) -> bool:
     """Execute the seeding operation."""
     if args.demo:
@@ -1816,6 +1845,7 @@ def _execute_seeding(args: argparse.Namespace) -> bool:
             from src.database.database_service import reset_database
 
             reset_database()
+            _clear_flask_sessions()
         return demo_seeder.seed_demo()
     else:
         baseline_seeder = BaselineTestSeeder()
@@ -1824,6 +1854,7 @@ def _execute_seeding(args: argparse.Namespace) -> bool:
             from src.database.database_service import reset_database
 
             reset_database()
+            _clear_flask_sessions()
 
         # Load manifest if provided
         manifest_data = None

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -539,6 +539,9 @@ class BaselineSeeder(ABC):
         term_map = term_id_or_map if isinstance(term_id_or_map, dict) else {}
 
         for offering_data in offerings_data:
+            # Skip JSON comment-only entries
+            if "_comment" in offering_data and len(offering_data) == 1:
+                continue
             course_id = self._resolve_course_id_from_manifest(offering_data, course_map)
             if not course_id:
                 continue
@@ -745,6 +748,9 @@ class BaselineSeeder(ABC):
         clo_count = 0
         status_lookup = self._status_lookup()
         for clo_data in specific_clos:
+            # Skip JSON comment-only entries (e.g. {"_comment": "..."})
+            if "_comment" in clo_data and len(clo_data) == 1:
+                continue
             target_course = self._resolve_target_course(
                 clo_data, course_ids, course_map
             )
@@ -1331,6 +1337,9 @@ class DemoSeeder(BaselineSeeder):
         status_lookup = self._status_lookup()
 
         for override in overrides:
+            # Skip JSON comment-only entries
+            if "_comment" in override and len(override) == 1:
+                continue
             course_code = override.get("course_code")
             section_number = override.get("section_number")
             clo_number = str(override.get("clo_number"))

--- a/src/api/routes/plos.py
+++ b/src/api/routes/plos.py
@@ -28,6 +28,7 @@ from src.services.plo_service import (
     get_mapping_matrix,
     get_or_create_draft,
     get_plo_dashboard_tree,
+    get_plo_trend_data,
     get_program_outcome,
     get_published_mappings,
     get_unmapped_clos,
@@ -530,3 +531,28 @@ def unmapped_clos(program_id: str) -> ResponseReturnValue:
         )
     except Exception as exc:
         return handle_api_error(exc, "fetching unmapped CLOs")
+
+
+@plo_bp.route("/<program_id>/plo-dashboard/trend", methods=["GET"])
+@permission_required("view_program_data")
+def plo_trend(program_id: str) -> ResponseReturnValue:
+    """Return multi-term trend data for the PLO dashboard.
+
+    Uses the current published mapping as a lens to aggregate assessment
+    data across all historical terms.  Each PLO and CLO gets a time-series
+    array aligned with the ``terms`` list in the response.
+
+    Response shape is documented in plo_service.get_plo_trend_data.
+    """
+    program, err = _validate_program(program_id)
+    if err:
+        return err
+
+    try:
+        trend = get_plo_trend_data(
+            program_id,
+            institution_id=program["institution_id"],
+        )
+        return jsonify({"success": True, **trend}), 200
+    except Exception as exc:
+        return handle_api_error(exc, "plo_trend", "Failed to build PLO trend data")

--- a/src/database/database_interface.py
+++ b/src/database/database_interface.py
@@ -267,6 +267,7 @@ class DatabaseInterface(ABC):
         course_id: Optional[str] = None,
         section_id: Optional[str] = None,
         outcome_ids: Optional[List[str]] = None,
+        term_ids: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Get section outcomes filtered by various criteria"""
         raise NotImplementedError

--- a/src/database/database_service.py
+++ b/src/database/database_service.py
@@ -743,6 +743,7 @@ def get_section_outcomes_by_criteria(
     course_id: Optional[str] = None,
     section_id: Optional[str] = None,
     outcome_ids: Optional[List[str]] = None,
+    term_ids: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get section outcomes filtered by various criteria.
@@ -751,12 +752,13 @@ def get_section_outcomes_by_criteria(
         institution_id: The institution ID
         status: The status to filter by
         program_id: The program ID to filter by
-        term_id: The term ID to filter by
+        term_id: The term ID to filter by (single term)
         course_id: The course ID to filter by
         section_id: The section ID to filter by
         outcome_ids: Restrict to section outcomes referencing these
             CourseOutcome template IDs (used by the PLO dashboard to fetch
             only sections using CLOs that are mapped to a given PLO set).
+        term_ids: Multiple term filter; when provided, overrides term_id.
 
     Returns:
         List of section outcome dictionaries
@@ -769,6 +771,7 @@ def get_section_outcomes_by_criteria(
         course_id,
         section_id,
         outcome_ids,
+        term_ids,
     )
 
 

--- a/src/database/database_sqlite.py
+++ b/src/database/database_sqlite.py
@@ -991,10 +991,15 @@ class SQLDatabase(DatabaseInterface):
         course_id: Optional[str] = None,
         section_id: Optional[str] = None,
         outcome_ids: Optional[List[str]] = None,
+        term_ids: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Get section outcomes filtered by various criteria.
         This is the source of truth for workflow audits (section-level granularity).
+
+        Args:
+            term_id: Single term filter (backward compat).
+            term_ids: Multiple term filter; when provided, overrides term_id.
 
         Performance Note: Uses eager loading to fetch all related data in one query
         to avoid N+1 query problems when displaying audit pages.
@@ -1041,7 +1046,9 @@ class SQLDatabase(DatabaseInterface):
             if outcome_ids:
                 query = query.where(CourseSectionOutcome.outcome_id.in_(outcome_ids))
 
-            if term_id:
+            if term_ids:
+                query = query.where(CourseOffering.term_id.in_(term_ids))
+            elif term_id:
                 query = query.where(CourseOffering.term_id == term_id)
 
             if program_id:

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -740,7 +740,7 @@ def write_db_generation() -> str:
     token = str(uuid.uuid4())
     DB_GENERATION_FILE.parent.mkdir(parents=True, exist_ok=True)
     DB_GENERATION_FILE.write_text(token)
-    logger.info("[Auth] Wrote new database generation token: %s", token)
+    logger.info("[Auth] Wrote new database generation token")
     return token
 
 

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -166,14 +166,45 @@ class AuthService:
             return self._get_mock_user()
 
     def _get_session_user(self) -> Optional[Dict[str, Any]]:
-        """Session-based authentication"""
+        """Session-based authentication with stale-session detection.
+
+        When the database is re-seeded with ``--clear``, a generation token is
+        written to ``data/.db_generation``.  At login the current token is
+        stored in the session.  On every subsequent request we compare the two:
+        if they diverge the DB has been re-seeded and this session is stale.
+        Destroying it forces a clean redirect to the login page instead of
+        letting the browser sit "logged in" with no visible data.
+
+        The check is a cheap file read — no DB round-trip — and is skipped
+        entirely when the file doesn't exist (e.g. in unit tests that don't
+        seed the database).
+        """
         from data.session import SessionService
 
         if not SessionService.is_user_logged_in():
             return None
 
         user = SessionService.get_current_user()
-        if user and not user.get("institution_id"):
+        if not user:
+            return None
+
+        # --- stale-session guard -------------------------------------------
+        session_gen = session.get("_db_generation")
+        if session_gen is not None:
+            current_gen = _read_db_generation()
+            if current_gen is not None and session_gen != current_gen:
+                logger.warning(
+                    "[Auth] Stale session detected for user_id=%s — "
+                    "database was re-seeded (session gen=%s, current gen=%s). "
+                    "Destroying session.",
+                    user.get("user_id"),
+                    session_gen,
+                    current_gen,
+                )
+                SessionService.destroy_session()
+                return None
+
+        if not user.get("institution_id"):
             resolved_id, _ = _resolve_institution_id_from_user(user)
             if resolved_id:
                 # Copy to avoid mutating the underlying session dict reference
@@ -664,6 +695,53 @@ def admin_required(f: Callable[..., Any]) -> Callable[..., Any]:
         return role_required(UserRole.SITE_ADMIN.value)(f)(*args, **kwargs)
 
     return decorated_function
+
+
+# ---------------------------------------------------------------------------
+#  Database generation token — stale-session detection
+# ---------------------------------------------------------------------------
+#  When seed_db.py runs with --clear it writes a UUID to this file.
+#  At login the token is copied into the session.  On every request
+#  _get_session_user() compares the two; a mismatch means the DB was
+#  re-seeded and the session is stale.
+# ---------------------------------------------------------------------------
+import os as _os
+import pathlib as _pathlib
+
+DB_GENERATION_FILE = (
+    _pathlib.Path(_os.environ.get("AGENT_HOME", _os.getcwd()))
+    / "data"
+    / ".db_generation"
+)
+
+
+def _read_db_generation() -> Optional[str]:
+    """Read the current database generation token from disk.
+
+    Returns ``None`` when the marker file does not exist (e.g. in test
+    environments that never run the seeder).
+    """
+    try:
+        return DB_GENERATION_FILE.read_text().strip()
+    except FileNotFoundError:
+        return None
+    except Exception:
+        logger.debug("[Auth] Could not read %s", DB_GENERATION_FILE)
+        return None
+
+
+def write_db_generation() -> str:
+    """Write a **new** database generation token and return it.
+
+    Called by the seed script after clearing the database.
+    """
+    import uuid
+
+    token = str(uuid.uuid4())
+    DB_GENERATION_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DB_GENERATION_FILE.write_text(token)
+    logger.info("[Auth] Wrote new database generation token: %s", token)
+    return token
 
 
 # Utility functions (working stubs)

--- a/src/services/plo_service.py
+++ b/src/services/plo_service.py
@@ -362,26 +362,6 @@ def get_plo_dashboard_tree(
                 "course_title": course.get("course_title"),
             }
 
-    def _aggregate(records: List[Dict[str, Any]]) -> Dict[str, Any]:
-        took = 0
-        passed = 0
-        counted = 0
-        for r in records:
-            t = r.get("students_took")
-            p = r.get("students_passed")
-            if isinstance(t, int) and t > 0 and isinstance(p, int):
-                took += t
-                passed += p
-                counted += 1
-        rate = round(passed / took * 100, 1) if took > 0 else None
-        return {
-            "students_took": took,
-            "students_passed": passed,
-            "pass_rate": rate,
-            "section_count": len(records),
-            "sections_with_data": counted,
-        }
-
     tree: List[Dict[str, Any]] = []
     for plo in plos:
         clo_nodes: List[Dict[str, Any]] = []
@@ -391,7 +371,7 @@ def get_plo_dashboard_tree(
             clo_nodes.append(
                 {
                     **meta,
-                    "aggregate": _aggregate(secs),
+                    "aggregate": _aggregate_section_outcomes(secs),
                     "sections": secs,
                 }
             )
@@ -400,7 +380,7 @@ def get_plo_dashboard_tree(
         tree.append(
             {
                 **plo,
-                "aggregate": _aggregate(all_plo_sections),
+                "aggregate": _aggregate_section_outcomes(all_plo_sections),
                 "clo_count": len(clo_nodes),
                 "clos": clo_nodes,
             }

--- a/src/services/plo_service.py
+++ b/src/services/plo_service.py
@@ -575,6 +575,67 @@ def _build_trend_point(
     return point
 
 
+def _detect_discontinuities(
+    clo_ids: List[str],
+    clo_meta: Dict[str, Dict[str, Any]],
+    by_clo_term: Dict[str, Dict[str, List[Dict[str, Any]]]],
+    term_meta: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Detect CLO composition changes between consecutive terms.
+
+    Compares the set of CLOs that have assessment data in each term.
+    When the set changes between term N and N+1, emits a discontinuity
+    marker recording which CLOs were added/removed.
+
+    Returns a list of discontinuity dicts, each with::
+
+        {
+            "term_index": int,       # index of the LATER term
+            "term_id": str,
+            "type": "clo_change",
+            "added": [{"clo_id", "label"}],  # CLOs new in this term
+            "removed": [{"clo_id", "label"}] # CLOs gone from prev term
+        }
+    """
+    discontinuities: List[Dict[str, Any]] = []
+
+    def _clo_label(clo_id: str) -> str:
+        meta = clo_meta.get(clo_id, {})
+        course = meta.get("course_number", "?")
+        num = meta.get("clo_number", "?")
+        return f"{course}/{num}"
+
+    prev_active: Optional[set] = None
+    for idx, tm in enumerate(term_meta):
+        tid = tm["term_id"]
+        active = {cid for cid in clo_ids if by_clo_term.get(cid, {}).get(tid)}
+
+        if prev_active is not None and active != prev_active:
+            added = active - prev_active
+            removed = prev_active - active
+            if added or removed:
+                discontinuities.append(
+                    {
+                        "term_index": idx,
+                        "term_id": tid,
+                        "type": "clo_change",
+                        "added": [
+                            {"clo_id": c, "label": _clo_label(c)} for c in sorted(added)
+                        ],
+                        "removed": [
+                            {"clo_id": c, "label": _clo_label(c)}
+                            for c in sorted(removed)
+                        ],
+                    }
+                )
+
+        # Only start tracking after the first term with any data
+        if active or prev_active is not None:
+            prev_active = active
+
+    return discontinuities
+
+
 def _assemble_plo_trends(
     plos: List[Dict[str, Any]],
     plo_to_clos: Dict[str, List[str]],
@@ -600,6 +661,11 @@ def _assemble_plo_trends(
                 all_records.extend(by_clo_term.get(clo_id, {}).get(tid, []))
             plo_trend_points.append(_build_trend_point(all_records, tid))
 
+        # Detect curriculum changes (CLO composition shifts between terms)
+        discontinuities = _detect_discontinuities(
+            clo_ids, clo_meta, by_clo_term, term_meta
+        )
+
         plo_results.append(
             {
                 "id": plo["id"],
@@ -607,6 +673,7 @@ def _assemble_plo_trends(
                 "description": plo_snapshots.get(plo["id"], plo.get("description")),
                 "trend": plo_trend_points,
                 "clos": clo_trends,
+                "discontinuities": discontinuities,
             }
         )
     return plo_results

--- a/src/services/plo_service.py
+++ b/src/services/plo_service.py
@@ -37,16 +37,26 @@ def get_program_outcome(plo_id: str) -> Optional[Dict[str, Any]]:
 def create_program_outcome(data: Dict[str, Any]) -> str:
     """Create a new PLO template.
 
-    Required keys: program_id, institution_id, plo_number, description.
+    Required keys: program_id, institution_id, description.
+    ``plo_number`` is optional – when omitted (or ``None``) the next
+    available number for the program is assigned automatically.
     Returns the new PLO ID.
 
     Raises:
         ValueError: if required fields are missing.
     """
-    required = ("program_id", "institution_id", "plo_number", "description")
+    required = ("program_id", "institution_id", "description")
     missing = [f for f in required if f not in data or data[f] is None]
     if missing:
         raise ValueError(f"Missing required fields: {', '.join(missing)}")
+
+    # Auto-assign next PLO number when not provided
+    if data.get("plo_number") is None:
+        existing = database_service.get_program_outcomes(
+            data["program_id"], include_inactive=True
+        )
+        max_num = max((p.get("plo_number", 0) or 0 for p in existing), default=0)
+        data["plo_number"] = max_num + 1
 
     plo_id = database_service.create_program_outcome(data)
     logger.info("Created PLO %s for program %s", plo_id, data["program_id"])

--- a/src/services/plo_service.py
+++ b/src/services/plo_service.py
@@ -6,10 +6,11 @@ around database_service that adds permission context, validation,
 and audit logging.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.database import database_service
 from src.utils.logging_config import get_logger
+from src.utils.term_utils import get_term_status
 
 logger = get_logger(__name__)
 
@@ -440,3 +441,305 @@ def get_unmapped_clos(
                 unmapped.append({**clo, "course": course})
 
     return unmapped
+
+
+# ---------------------------------------------------------------------------
+# Trend data (multi-term time series)
+# ---------------------------------------------------------------------------
+
+
+def _build_term_metadata(
+    all_terms: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Convert raw term rows into metadata dicts with ``is_current`` flag."""
+    meta: List[Dict[str, Any]] = []
+    for t in all_terms:
+        status = get_term_status(
+            str(t.get("start_date", "")),
+            str(t.get("end_date", "")),
+        )
+        meta.append(
+            {
+                "term_id": t.get("id") or t.get("term_id"),
+                "term_name": t.get("name") or t.get("term_name", ""),
+                "start_date": t.get("start_date", ""),
+                "is_current": status == "ACTIVE",
+            }
+        )
+    return meta
+
+
+def _resolve_plo_clo_mapping(
+    program_id: str,
+    plos: List[Dict[str, Any]],
+) -> Tuple[Optional[int], Dict[str, List[str]], set, Dict[str, str]]:
+    """Resolve latest published mapping and build PLO → CLO index.
+
+    Returns:
+        (mapping_version, plo_to_clos, all_clo_ids, plo_snapshots)
+    """
+    mapping = database_service.get_latest_published_plo_mapping(program_id)
+    mapping_version = mapping.get("version") if mapping else None
+    entries = mapping.get("entries", []) if mapping else []
+
+    plo_to_clos: Dict[str, List[str]] = {p["id"]: [] for p in plos}
+    all_clo_ids: set[str] = set()
+    plo_snapshots: Dict[str, str] = {}
+
+    for entry in entries:
+        plo_id = entry.get("program_outcome_id")
+        clo_id = entry.get("course_outcome_id")
+        if plo_id in plo_to_clos and clo_id:
+            plo_to_clos[plo_id].append(clo_id)
+            all_clo_ids.add(clo_id)
+            snap = entry.get("plo_description_snapshot")
+            if snap and plo_id not in plo_snapshots:
+                plo_snapshots[plo_id] = snap
+
+    return mapping_version, plo_to_clos, all_clo_ids, plo_snapshots
+
+
+def _index_outcomes_by_clo_term(
+    section_outcomes: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """Index section outcomes into ``{clo_id: {term_id: [records]}}``."""
+    by_clo_term: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    for so in section_outcomes:
+        clo_id = so.get("outcome_id")
+        so_term_id = _extract_term_id(so)
+        if clo_id and so_term_id:
+            by_clo_term.setdefault(clo_id, {}).setdefault(so_term_id, []).append(so)
+    return by_clo_term
+
+
+def _build_clo_metadata(
+    program_id: str,
+) -> Dict[str, Dict[str, Any]]:
+    """Build ``{clo_id: {outcome_id, clo_number, description, course_number}}``."""
+    clo_meta: Dict[str, Dict[str, Any]] = {}
+    courses = database_service.get_courses_by_program(program_id)
+    for course in courses:
+        for clo in database_service.get_course_outcomes(course["course_id"]):
+            clo_meta[clo["outcome_id"]] = {
+                "outcome_id": clo["outcome_id"],
+                "clo_number": clo.get("clo_number"),
+                "description": clo.get("description"),
+                "course_number": course.get("course_number"),
+            }
+    return clo_meta
+
+
+def _aggregate_section_outcomes(
+    records: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Aggregate section outcomes into a single trend data point."""
+    took = 0
+    passed = 0
+    counted = 0
+    for r in records:
+        t = r.get("students_took")
+        p = r.get("students_passed")
+        if isinstance(t, int) and t > 0 and isinstance(p, int):
+            took += t
+            passed += p
+            counted += 1
+    rate = round(passed / took * 100, 1) if took > 0 else None
+    return {
+        "students_took": took,
+        "students_passed": passed,
+        "pass_rate": rate,
+        "section_count": len(records),
+        "sections_with_data": counted,
+    }
+
+
+def _build_trend_point(
+    records: List[Dict[str, Any]],
+    term_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Return an aggregated trend point for *records*, or ``None`` if empty."""
+    if not records:
+        return None
+    point = _aggregate_section_outcomes(records)
+    point["term_id"] = term_id
+    return point
+
+
+def _assemble_plo_trends(
+    plos: List[Dict[str, Any]],
+    plo_to_clos: Dict[str, List[str]],
+    clo_meta: Dict[str, Dict[str, Any]],
+    by_clo_term: Dict[str, Dict[str, List[Dict[str, Any]]]],
+    term_meta: List[Dict[str, Any]],
+    plo_snapshots: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Assemble per-PLO and per-CLO trend arrays."""
+    plo_results: List[Dict[str, Any]] = []
+    for plo in plos:
+        clo_ids = plo_to_clos.get(plo["id"], [])
+
+        # CLO-level trends
+        clo_trends = _build_clo_trends(clo_ids, clo_meta, by_clo_term, term_meta)
+
+        # PLO-level trend (aggregate across all CLOs per term)
+        plo_trend_points: List[Optional[Dict[str, Any]]] = []
+        for tm in term_meta:
+            tid = tm["term_id"]
+            all_records: List[Dict[str, Any]] = []
+            for clo_id in clo_ids:
+                all_records.extend(by_clo_term.get(clo_id, {}).get(tid, []))
+            plo_trend_points.append(_build_trend_point(all_records, tid))
+
+        plo_results.append(
+            {
+                "id": plo["id"],
+                "plo_number": plo.get("plo_number"),
+                "description": plo_snapshots.get(plo["id"], plo.get("description")),
+                "trend": plo_trend_points,
+                "clos": clo_trends,
+            }
+        )
+    return plo_results
+
+
+def _build_clo_trends(
+    clo_ids: List[str],
+    clo_meta: Dict[str, Dict[str, Any]],
+    by_clo_term: Dict[str, Dict[str, List[Dict[str, Any]]]],
+    term_meta: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Build per-CLO trend arrays across all terms."""
+    clo_trends: List[Dict[str, Any]] = []
+    for clo_id in clo_ids:
+        meta = clo_meta.get(clo_id, {"outcome_id": clo_id})
+        clo_trend_points: List[Optional[Dict[str, Any]]] = []
+        for tm in term_meta:
+            tid = tm["term_id"]
+            records = by_clo_term.get(clo_id, {}).get(tid, [])
+            clo_trend_points.append(_build_trend_point(records, tid))
+        clo_trends.append({**meta, "trend": clo_trend_points})
+    return clo_trends
+
+
+def get_plo_trend_data(
+    program_id: str,
+    institution_id: str,
+) -> Dict[str, Any]:
+    """Build multi-term trend data for a program's PLO dashboard.
+
+    Uses the **current** published mapping as a "lens" to look back through
+    all historical terms.  This means the mapping is fixed (today's PLO↔CLO
+    links), but assessment data comes from each term independently.
+
+    Defensive design against data volatility:
+    - Queries by CLO IDs directly (skips ``course_programs`` join issues).
+    - Uses ``null`` for terms where a CLO had no data (not ``0``).
+    - Includes ``is_current`` flag for in-progress terms.
+    - Carries ``plo_description_snapshot`` from mapping entries when available.
+
+    Returns::
+
+        {
+            "program_id": str,
+            "mapping_version": int | None,
+            "terms": [
+                {"term_id": str, "term_name": str, "is_current": bool}, ...
+            ],
+            "plos": [
+                {
+                    "id": str, "plo_number": int, "description": str,
+                    "trend": [
+                        {"term_id": str, "pass_rate": float | None,
+                         "students_took": int, "students_passed": int,
+                         "section_count": int} | None, ...
+                    ],
+                    "clos": [
+                        {
+                            "outcome_id": str, "clo_number": str,
+                            "description": str, "course_number": str,
+                            "trend": [ ... ]   # same shape per term
+                        }, ...
+                    ]
+                }, ...
+            ]
+        }
+    """
+    # 1. Get all terms, sorted chronologically (oldest first for charting)
+    all_terms = database_service.get_all_terms(institution_id)
+    all_terms.sort(key=lambda t: t.get("start_date", ""))
+
+    if not all_terms:
+        return {
+            "program_id": program_id,
+            "mapping_version": None,
+            "terms": [],
+            "plos": [],
+        }
+
+    term_meta = _build_term_metadata(all_terms)
+    term_ids = [tm["term_id"] for tm in term_meta]
+
+    # 2. Resolve mapping → PLO↔CLO associations
+    plos = database_service.get_program_outcomes(program_id)
+    mapping_version, plo_to_clos, all_clo_ids, plo_snapshots = _resolve_plo_clo_mapping(
+        program_id, plos
+    )
+
+    # 3. Fetch ALL section outcomes across ALL terms in one query
+    all_section_outcomes: List[Dict[str, Any]] = []
+    if all_clo_ids and term_ids:
+        all_section_outcomes = database_service.get_section_outcomes_by_criteria(
+            institution_id=institution_id,
+            outcome_ids=list(all_clo_ids),
+            term_ids=term_ids,
+        )
+
+    # 4. Index by (clo_id, term_id) and build CLO metadata
+    by_clo_term = _index_outcomes_by_clo_term(all_section_outcomes)
+    clo_meta = _build_clo_metadata(program_id)
+
+    # 5. Assemble trend results
+    plo_results = _assemble_plo_trends(
+        plos, plo_to_clos, clo_meta, by_clo_term, term_meta, plo_snapshots
+    )
+
+    return {
+        "program_id": program_id,
+        "mapping_version": mapping_version,
+        "terms": term_meta,
+        "plos": plo_results,
+    }
+
+
+def _extract_term_id(section_outcome: Dict[str, Any]) -> Optional[str]:
+    """Extract term_id from a section outcome's nested relationships.
+
+    The ``to_dict`` serialisation nests the offering's term under
+    ``_section._offering.term_id`` (or similar paths).  We walk the
+    common shapes to find the term identifier.
+    """
+    # Direct term_id on the section outcome (simplest)
+    tid = section_outcome.get("term_id")
+    if tid:
+        return str(tid)
+
+    # Nested: _section → _offering → term_id
+    sec = section_outcome.get("_section") or section_outcome.get("section") or {}
+    off = sec.get("_offering") or sec.get("offering") or {}
+    tid = off.get("term_id")
+    if tid:
+        return str(tid)
+
+    # Nested: _offering → term_id (flatter serialisation)
+    off2 = section_outcome.get("_offering") or section_outcome.get("offering") or {}
+    tid = off2.get("term_id")
+    if tid:
+        return str(tid)
+
+    # Nested term object
+    term = off.get("_term") or off.get("term") or off2.get("_term") or {}
+    tid = term.get("id") or term.get("term_id")
+    if tid:
+        return str(tid)
+
+    return None

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -134,15 +134,135 @@
 }
 
 /* ------------------------------------------------------------------ */
-/* Trend sparklines + drill-down panels                                */
+/* Trend indicators + drill-down panels                                */
 /* ------------------------------------------------------------------ */
 
-/* Inline sparkline wrapper (sits next to the assessment badge) */
+/* Compact trend indicator (replaces sparkline in collapsed row) */
+.plo-trend-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.plo-trend-indicator.trend-up {
+  background-color: rgba(25, 135, 84, 0.1);
+}
+
+.plo-trend-indicator.trend-down {
+  background-color: rgba(220, 53, 69, 0.1);
+}
+
+.plo-trend-indicator.trend-flat {
+  background-color: rgba(108, 117, 125, 0.08);
+}
+
+.plo-trend-indicator:hover {
+  filter: brightness(0.95);
+}
+
+.plo-trend-delta {
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.trend-up .plo-trend-delta {
+  color: #198754;
+}
+
+.trend-down .plo-trend-delta {
+  color: #dc3545;
+}
+
+.trend-flat .plo-trend-delta {
+  color: #6c757d;
+}
+
+/* Legacy sparkline wrapper (kept for createSparkline function) */
 .plo-sparkline-wrap {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
   cursor: pointer;
+}
+
+/* ------------------------------------------------------------------ */
+/* Program summary bar                                                 */
+/* ------------------------------------------------------------------ */
+
+.plo-summary-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.625rem 0;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.plo-summary-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: #495057;
+}
+
+.plo-summary-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-weight: 500;
+}
+
+.plo-summary-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.stat-pass .plo-summary-dot {
+  background-color: #198754;
+}
+
+.stat-fail .plo-summary-dot {
+  background-color: #dc3545;
+}
+
+.stat-nodata .plo-summary-dot {
+  background-color: #adb5bd;
+}
+
+.plo-summary-progress {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background-color: #e9ecef;
+}
+
+.plo-summary-segment {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.seg-pass {
+  background-color: #198754;
+}
+
+.seg-fail {
+  background-color: #dc3545;
+}
+
+.seg-nodata {
+  background-color: #adb5bd;
 }
 
 .plo-sparkline {

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -155,8 +155,16 @@
   background-color: rgba(25, 135, 84, 0.1);
 }
 
+.plo-trend-indicator.trend-strong-up {
+  background-color: rgba(25, 135, 84, 0.18);
+}
+
 .plo-trend-indicator.trend-down {
   background-color: rgba(220, 53, 69, 0.1);
+}
+
+.plo-trend-indicator.trend-strong-down {
+  background-color: rgba(220, 53, 69, 0.18);
 }
 
 .plo-trend-indicator.trend-flat {
@@ -177,7 +185,15 @@
   color: #198754;
 }
 
+.trend-strong-up .plo-trend-delta {
+  color: #198754;
+}
+
 .trend-down .plo-trend-delta {
+  color: #dc3545;
+}
+
+.trend-strong-down .plo-trend-delta {
   color: #dc3545;
 }
 
@@ -297,7 +313,15 @@
   color: #198754;
 }
 
+.plo-trend-arrow.trend-strong-up {
+  color: #198754;
+}
+
 .plo-trend-arrow.trend-down {
+  color: #dc3545;
+}
+
+.plo-trend-arrow.trend-strong-down {
   color: #dc3545;
 }
 
@@ -468,6 +492,13 @@
   font-size: 0.7rem;
   color: #6c757d;
   font-weight: 500;
+}
+
+/* Mini trend indicator inside sparkline slots */
+.plo-trend-indicator--mini {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.5rem;
 }
 
 /* Trend panels inside summary bar need tighter margins */

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -213,6 +213,59 @@
   max-height: 200px;
 }
 
+/* CLO Composition bar (shows which courses contributed per term) */
+.plo-composition-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  padding: 0.375rem 0 0.25rem;
+  margin-top: 0.25rem;
+  border-top: 1px solid #e9ecef;
+}
+
+.plo-comp-cell {
+  flex: 1 1 0;
+  display: flex;
+  justify-content: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.plo-comp-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  cursor: default;
+}
+
+.plo-comp-dot.plo-comp-empty {
+  background-color: #e9ecef;
+}
+
+.plo-comp-legend {
+  width: 100%;
+  display: flex;
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+  font-size: 0.7rem;
+  color: #6c757d;
+}
+
+.plo-comp-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.plo-comp-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
 /* All-programs heading separator */
 .plo-all-programs-heading {
   border-bottom: 1px solid #dee2e6;

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -189,28 +189,34 @@
   min-height: 200px;
 }
 
-.plo-trend-panel-close {
+.plo-trend-panel-toggle {
   position: absolute;
   top: 0.25rem;
   right: 0.5rem;
   border: none;
   background: none;
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   line-height: 1;
   color: #6c757d;
   cursor: pointer;
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   z-index: 1;
+  opacity: 0.6;
+  transition: opacity 0.15s;
 }
 
-.plo-trend-panel-close:hover {
-  color: #dc3545;
-  background-color: rgba(220, 53, 69, 0.08);
+.plo-trend-panel-toggle:hover {
+  opacity: 1;
+}
+
+.plo-trend-panel--collapsed {
+  min-height: auto;
+  padding-bottom: 0.25rem;
 }
 
 .plo-trend-panel canvas {
-  max-height: 200px;
+  max-height: 300px;
 }
 
 /* CLO Composition bar (shows which courses contributed per term) */

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -180,6 +180,7 @@
 
 /* Expanded trend chart panel (click sparkline to open) */
 .plo-trend-panel {
+  position: relative;
   padding: 0.75rem 1rem;
   margin: 0 0.5rem 0.5rem 2.5rem;
   background-color: #f8f9fa;
@@ -188,6 +189,32 @@
   min-height: 200px;
 }
 
+.plo-trend-panel-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  border: none;
+  background: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: #6c757d;
+  cursor: pointer;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  z-index: 1;
+}
+
+.plo-trend-panel-close:hover {
+  color: #dc3545;
+  background-color: rgba(220, 53, 69, 0.08);
+}
+
 .plo-trend-panel canvas {
   max-height: 200px;
+}
+
+/* All-programs heading separator */
+.plo-all-programs-heading {
+  border-bottom: 1px solid #dee2e6;
+  padding-bottom: 0.5rem;
 }

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -132,3 +132,62 @@
   padding: 0.1rem 0.4rem;
   border-radius: 0.75rem;
 }
+
+/* ------------------------------------------------------------------ */
+/* Trend sparklines + drill-down panels                                */
+/* ------------------------------------------------------------------ */
+
+/* Inline sparkline wrapper (sits next to the assessment badge) */
+.plo-sparkline-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.plo-sparkline {
+  vertical-align: middle;
+  border-radius: 3px;
+  transition: box-shadow 0.15s ease;
+}
+
+.plo-sparkline:hover {
+  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25);
+}
+
+/* Trend direction arrows */
+.plo-trend-arrow {
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.plo-trend-arrow.trend-up {
+  color: #198754;
+}
+
+.plo-trend-arrow.trend-down {
+  color: #dc3545;
+}
+
+.plo-trend-arrow.trend-flat {
+  color: #6c757d;
+}
+
+.plo-trend-arrow.trend-none {
+  display: none;
+}
+
+/* Expanded trend chart panel (click sparkline to open) */
+.plo-trend-panel {
+  padding: 0.75rem 1rem;
+  margin: 0 0.5rem 0.5rem 2.5rem;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 0.5rem;
+  min-height: 200px;
+}
+
+.plo-trend-panel canvas {
+  max-height: 200px;
+}

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -276,12 +276,14 @@
 
 .plo-sparkline {
   vertical-align: middle;
-  border-radius: 3px;
-  transition: box-shadow 0.15s ease;
+  border-radius: 6px;
+  background: linear-gradient(180deg, rgba(248, 249, 250, 0.8), rgba(248, 249, 250, 0));
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 .plo-sparkline:hover {
-  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25);
+  box-shadow: 0 1px 6px rgba(13, 110, 253, 0.2);
+  transform: scale(1.08);
 }
 
 /* Trend direction arrows */
@@ -451,8 +453,15 @@
 .plo-summary-sparkline-slot {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: 0.25rem;
   cursor: pointer;
+  padding: 0.2rem 0.35rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.15s ease;
+}
+
+.plo-summary-sparkline-slot:hover {
+  background-color: rgba(13, 110, 253, 0.06);
 }
 
 .plo-summary-sparkline-label {

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -179,6 +179,11 @@
 }
 
 /* Expanded trend chart panel (click sparkline to open) */
+/* Hide trend panel when node is collapsed */
+.plo-tree-node:not(.expanded) > .plo-trend-panel {
+  display: none;
+}
+
 .plo-trend-panel {
   position: relative;
   padding: 0.75rem 1rem;

--- a/static/plo_dashboard.css
+++ b/static/plo_dashboard.css
@@ -206,6 +206,15 @@
   border-bottom: 1px solid #e9ecef;
 }
 
+.plo-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: #495057;
+  flex-wrap: wrap;
+}
+
 .plo-summary-stats {
   display: flex;
   align-items: center;
@@ -401,4 +410,59 @@
 .plo-all-programs-heading {
   border-bottom: 1px solid #dee2e6;
   padding-bottom: 0.5rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Collapsible program sections (All Programs view)                    */
+/* ------------------------------------------------------------------ */
+
+.plo-program-section.collapsed .plo-program-content {
+  display: none;
+}
+
+.plo-program-toggle {
+  display: inline-block;
+  width: 1.25rem;
+  text-align: center;
+  color: #6c757d;
+  transition: transform 0.15s ease;
+  margin-right: 0.25rem;
+}
+
+.plo-program-section.collapsed .plo-program-toggle {
+  transform: rotate(-90deg);
+}
+
+.plo-all-programs-heading:hover {
+  color: #0d6efd;
+}
+
+/* ------------------------------------------------------------------ */
+/* Summary bar sparkline slots                                         */
+/* ------------------------------------------------------------------ */
+
+.plo-summary-sparkline-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.plo-summary-sparkline-slot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.plo-summary-sparkline-label {
+  font-size: 0.7rem;
+  color: #6c757d;
+  font-weight: 500;
+}
+
+/* Trend panels inside summary bar need tighter margins */
+.plo-summary-bar .plo-trend-panel {
+  margin-left: 0;
+  margin-right: 0;
 }

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -139,8 +139,7 @@
         el.displayMode.addEventListener("change", () => {
           this.displayMode = el.displayMode.value;
           this._persistDisplayMode();
-          this._renderTree();
-          this._loadTrendData();
+          this._refreshBadges();
         });
       }
       if (el.expandAllBtn) {
@@ -390,6 +389,22 @@
       }
     },
 
+    /**
+     * Update all assessment badges in-place for the current displayMode
+     * without rebuilding the DOM tree (preserves expanded/collapsed state).
+     */
+    _refreshBadges() {
+      const container = this._el.treeContainer;
+      if (!container) return;
+      container.querySelectorAll(".plo-assessment-badge").forEach((badge) => {
+        const raw = badge.dataset.passRate;
+        const passRate = raw === "" || raw == null ? null : Number(raw);
+        const { text, cssClass } = formatAssessment(passRate, this.displayMode);
+        badge.className = "plo-assessment-badge " + cssClass;
+        badge.textContent = text;
+      });
+    },
+
     _renderTree() {
       const container = this._el.treeContainer;
       if (!container) return;
@@ -570,6 +585,7 @@
       badge.className = "plo-assessment-badge";
       const passRate =
         aggregate && aggregate.pass_rate != null ? aggregate.pass_rate : null;
+      badge.dataset.passRate = passRate === null ? "" : String(passRate);
       const { text, cssClass } = formatAssessment(passRate, this.displayMode);
       badge.classList.add(cssClass);
       badge.textContent = text;

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -354,6 +354,7 @@
 
           // Render tree for this program
           if (data.plos && data.plos.length > 0) {
+            container.appendChild(this._buildSummaryBar(data.plos));
             const ul = document.createElement("ul");
             ul.className = "plo-tree";
             const savedTree = this.tree;
@@ -459,7 +460,64 @@
       data.plos.forEach((plo) => ul.appendChild(this._buildPloNode(plo)));
 
       container.innerHTML = "";
+      container.appendChild(this._buildSummaryBar(data.plos));
       container.appendChild(ul);
+    },
+
+    /**
+     * Build a compact summary bar showing PLO status distribution.
+     * Displays counts of satisfactory / needs-attention / no-data PLOs
+     * with a proportional progress bar.
+     */
+    _buildSummaryBar(plos) {
+      const bar = document.createElement("div");
+      bar.className = "plo-summary-bar";
+      if (!plos || plos.length === 0) return bar;
+
+      const threshold = 70;
+      let satisfactory = 0;
+      let unsatisfactory = 0;
+      let nodata = 0;
+      plos.forEach((plo) => {
+        const rate = plo.aggregate && plo.aggregate.pass_rate;
+        if (rate === null || rate === undefined) nodata++;
+        else if (rate >= threshold) satisfactory++;
+        else unsatisfactory++;
+      });
+      const total = plos.length;
+
+      // Stats text
+      const stats = document.createElement("div");
+      stats.className = "plo-summary-stats";
+      const addStat = (count, label, cls) => {
+        if (count === 0) return;
+        const span = document.createElement("span");
+        span.className = "plo-summary-stat " + cls;
+        span.innerHTML =
+          '<span class="plo-summary-dot"></span>' + count + " " + label;
+        stats.appendChild(span);
+      };
+      addStat(satisfactory, "satisfactory", "stat-pass");
+      addStat(unsatisfactory, "needs attention", "stat-fail");
+      addStat(nodata, "no data", "stat-nodata");
+      bar.appendChild(stats);
+
+      // Progress bar
+      const progress = document.createElement("div");
+      progress.className = "plo-summary-progress";
+      const addSegment = (count, cls) => {
+        if (count === 0) return;
+        const seg = document.createElement("div");
+        seg.className = "plo-summary-segment " + cls;
+        seg.style.width = (count / total) * 100 + "%";
+        progress.appendChild(seg);
+      };
+      addSegment(satisfactory, "seg-pass");
+      addSegment(unsatisfactory, "seg-fail");
+      addSegment(nodata, "seg-nodata");
+      bar.appendChild(progress);
+
+      return bar;
     },
 
     // ===================================================================

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -104,6 +104,7 @@
         ploForm: document.getElementById("ploForm"),
         ploModalId: document.getElementById("ploModalId"),
         ploModalNumber: document.getElementById("ploModalNumber"),
+        ploModalNumberGroup: document.getElementById("ploModalNumberGroup"),
         ploModalDescription: document.getElementById("ploModalDescription"),
         ploModalLabel: document.getElementById("ploModalLabel"),
         ploModalAlert: document.getElementById("ploModalAlert"),
@@ -679,11 +680,19 @@
         el.ploModalId.value = plo.id;
         el.ploModalNumber.value = plo.plo_number || "";
         el.ploModalDescription.value = plo.description || "";
+        // Show PLO number (read-only) when editing
+        if (el.ploModalNumberGroup) {
+          el.ploModalNumberGroup.classList.remove("d-none");
+        }
       } else {
         el.ploModalLabel.textContent = "New Program Outcome";
         el.ploModalId.value = "";
         el.ploModalNumber.value = "";
         el.ploModalDescription.value = "";
+        // Hide PLO number on create — auto-assigned by server
+        if (el.ploModalNumberGroup) {
+          el.ploModalNumberGroup.classList.add("d-none");
+        }
       }
       this._showModal(el.ploModal);
     },
@@ -693,15 +702,16 @@
       const el = this._el;
       const pid = this.currentProgramId;
       const ploId = el.ploModalId.value;
-      // plo_number is stored as an INTEGER — coerce textual input so the
-      // unique constraint (program_id, plo_number) behaves consistently and
-      // ordering in get_program_outcomes() is numeric.
-      const rawNum = el.ploModalNumber.value.trim();
-      const parsed = parseInt(rawNum, 10);
       const body = {
-        plo_number: Number.isFinite(parsed) ? parsed : rawNum,
         description: el.ploModalDescription.value.trim(),
       };
+      // On edit, include the (read-only) plo_number; on create, omit it
+      // so the server auto-assigns the next available number.
+      if (ploId) {
+        const rawNum = el.ploModalNumber.value.trim();
+        const parsed = parseInt(rawNum, 10);
+        body.plo_number = Number.isFinite(parsed) ? parsed : rawNum;
+      }
 
       const method = ploId ? "PUT" : "POST";
       const url = ploId

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -413,7 +413,7 @@
       if (typeof globalThis === "undefined" || !globalThis.PloTrend) return;
       for (const prog of this.programs) {
         const progId = prog.program_id || prog.id;
-        globalThis.PloTrend.loadTrend(progId);
+        globalThis.PloTrend.loadTrend(progId, this.currentTermId);
       }
     },
 
@@ -427,7 +427,10 @@
         globalThis.PloTrend &&
         this.currentProgramId
       ) {
-        globalThis.PloTrend.loadTrend(this.currentProgramId);
+        globalThis.PloTrend.loadTrend(
+          this.currentProgramId,
+          this.currentTermId,
+        );
       }
     },
 

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -122,6 +122,7 @@
       if (el.programFilter) {
         el.programFilter.addEventListener("change", () => {
           this.currentProgramId = el.programFilter.value;
+          this._updateProgramActions();
           try {
             localStorage.setItem(STORAGE_KEY_PROGRAM, this.currentProgramId);
           } catch (_) {
@@ -253,11 +254,27 @@
       this.currentTermId = defaultTerm;
     },
 
+    /**
+     * Show / hide program-specific action buttons ("New PLO", "Map CLO to PLO")
+     * based on whether a specific program is selected vs "All Programs".
+     */
+    _updateProgramActions() {
+      const el = this._el;
+      const hasProgram = !!this.currentProgramId;
+      if (el.createPloBtn) {
+        el.createPloBtn.style.display = hasProgram ? "" : "none";
+      }
+      if (el.mapCloBtn) {
+        el.mapCloBtn.style.display = hasProgram ? "" : "none";
+      }
+    },
+
     // ===================================================================
     // Tree fetch + render
     // ===================================================================
     async loadTree() {
       const pid = this.currentProgramId;
+      this._updateProgramActions();
 
       // "All Programs" mode — load each program's tree
       if (!pid) {
@@ -701,6 +718,14 @@
       e.preventDefault();
       const el = this._el;
       const pid = this.currentProgramId;
+      if (!pid) {
+        this._modalAlert(
+          el.ploModalAlert,
+          "Please select a specific program first.",
+          "danger",
+        );
+        return;
+      }
       const ploId = el.ploModalId.value;
       const body = {
         description: el.ploModalDescription.value.trim(),

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -288,8 +288,23 @@
         this.draftMappingId = null; // reset; re-fetched when modal opens
         this._renderTree();
         this._updateStats(data);
+        this._loadTrendData();
       } catch (err) {
         setErrorState("ploTreeContainer", `Error: ${err.message}`);
+      }
+    },
+
+    /**
+     * Load trend sparklines after the tree has been rendered.
+     * Delegates to PloTrend (plo_trend.js) if available.
+     */
+    _loadTrendData() {
+      if (
+        typeof globalThis !== "undefined" &&
+        globalThis.PloTrend &&
+        this.currentProgramId
+      ) {
+        globalThis.PloTrend.loadTrend(this.currentProgramId);
       }
     },
 

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -95,10 +95,6 @@
         treeContainer: document.getElementById("ploTreeContainer"),
         programName: document.getElementById("ploTreeProgramName"),
         versionBadge: document.getElementById("ploTreeVersionBadge"),
-        statPloCount: document.getElementById("statPloCount"),
-        statMappedCloCount: document.getElementById("statMappedCloCount"),
-        statOverallPassRate: document.getElementById("statOverallPassRate"),
-        statMappingStatus: document.getElementById("statMappingStatus"),
         expandAllBtn: document.getElementById("expandAllBtn"),
         collapseAllBtn: document.getElementById("collapseAllBtn"),
         createPloBtn: document.getElementById("createPloBtn"),
@@ -144,6 +140,7 @@
           this.displayMode = el.displayMode.value;
           this._persistDisplayMode();
           this._renderTree();
+          this._loadTrendData();
         });
       }
       if (el.expandAllBtn) {
@@ -200,6 +197,12 @@
         return;
       }
 
+      // "All Programs" option for institution admins
+      const allOpt = document.createElement("option");
+      allOpt.value = "";
+      allOpt.textContent = "All Programs";
+      sel.appendChild(allOpt);
+
       this.programs.forEach((p) => {
         const opt = document.createElement("option");
         opt.value = p.program_id || p.id;
@@ -207,7 +210,7 @@
         sel.appendChild(opt);
       });
 
-      // Default program: last selected (localStorage) → first in list
+      // Default program: last selected (localStorage) → "All Programs"
       let initial = null;
       try {
         initial = localStorage.getItem(STORAGE_KEY_PROGRAM);
@@ -216,7 +219,7 @@
       }
       const validIds = this.programs.map((p) => p.program_id || p.id);
       if (!initial || !validIds.includes(initial)) {
-        initial = validIds[0];
+        initial = ""; // default to All Programs
       }
       sel.value = initial;
       this.currentProgramId = initial;
@@ -255,14 +258,18 @@
     // ===================================================================
     async loadTree() {
       const pid = this.currentProgramId;
+
+      // "All Programs" mode — load each program's tree
       if (!pid) {
-        setEmptyState(
-          "ploTreeContainer",
-          "Select a program to see its outcomes.",
-        );
-        this._updateStats(null);
+        if (this.programs.length === 0) {
+          setEmptyState("ploTreeContainer", "No programs available.");
+          return;
+        }
+        setLoadingState("ploTreeContainer", "Loading all programs…");
+        await this._loadAllPrograms();
         return;
       }
+
       setLoadingState("ploTreeContainer", "Loading PLO tree…");
 
       const qs = new URLSearchParams();
@@ -287,10 +294,85 @@
         if (this._el.displayMode) this._el.displayMode.value = this.displayMode;
         this.draftMappingId = null; // reset; re-fetched when modal opens
         this._renderTree();
-        this._updateStats(data);
         this._loadTrendData();
       } catch (err) {
         setErrorState("ploTreeContainer", `Error: ${err.message}`);
+      }
+    },
+
+    /**
+     * Load and render PLO trees for every program (bird's-eye view).
+     */
+    async _loadAllPrograms() {
+      const container = this._el.treeContainer;
+      if (!container) return;
+      container.innerHTML = "";
+
+      const qs = new URLSearchParams();
+      if (this.currentTermId) qs.set("term_id", this.currentTermId);
+
+      for (const prog of this.programs) {
+        const progId = prog.program_id || prog.id;
+        const url = `/api/programs/${encodeURIComponent(progId)}/plo-dashboard?${qs}`;
+        try {
+          const resp = await fetch(url, {
+            credentials: "include",
+            headers: { Accept: "application/json" },
+          });
+          if (!resp.ok) continue;
+          const data = await resp.json();
+
+          // Program section heading
+          const heading = document.createElement("h5");
+          heading.className = "mt-3 mb-2 plo-all-programs-heading";
+          heading.textContent = prog.name;
+          if (data.mapping && data.mapping.version) {
+            const badge = document.createElement("span");
+            badge.className = "badge bg-secondary ms-2";
+            badge.textContent = `v${data.mapping.version}`;
+            heading.appendChild(badge);
+          }
+          container.appendChild(heading);
+
+          // Render tree for this program
+          if (data.plos && data.plos.length > 0) {
+            const ul = document.createElement("ul");
+            ul.className = "plo-tree";
+            const savedTree = this.tree;
+            this.tree = data;
+            data.plos.forEach((plo) => ul.appendChild(this._buildPloNode(plo)));
+            this.tree = savedTree;
+            container.appendChild(ul);
+          } else {
+            const empty = document.createElement("p");
+            empty.className = "text-muted small fst-italic ms-3 mb-3";
+            empty.textContent = "No PLOs defined.";
+            container.appendChild(empty);
+          }
+        } catch (_) {
+          // skip programs that fail to load
+        }
+      }
+
+      // Load trend sparklines for each program
+      this._loadAllTrendData();
+
+      if (this._el.programName) {
+        this._el.programName.textContent = "All Programs";
+      }
+      if (this._el.versionBadge) {
+        this._el.versionBadge.style.display = "none";
+      }
+    },
+
+    /**
+     * Load trend data for all programs (used in All Programs mode).
+     */
+    _loadAllTrendData() {
+      if (typeof globalThis === "undefined" || !globalThis.PloTrend) return;
+      for (const prog of this.programs) {
+        const progId = prog.program_id || prog.id;
+        globalThis.PloTrend.loadTrend(progId);
       }
     },
 
@@ -344,50 +426,6 @@
 
       container.innerHTML = "";
       container.appendChild(ul);
-    },
-
-    _updateStats(data) {
-      const set = (el, val) => {
-        if (el) el.textContent = val;
-      };
-      if (!data) {
-        set(this._el.statPloCount, "-");
-        set(this._el.statMappedCloCount, "-");
-        set(this._el.statOverallPassRate, "-");
-        set(this._el.statMappingStatus, "-");
-        return;
-      }
-      const plos = data.plos || [];
-      const cloCount = plos.reduce((n, p) => n + (p.clo_count || 0), 0);
-      set(this._el.statPloCount, plos.length);
-      set(this._el.statMappedCloCount, cloCount);
-
-      // overall pass rate aggregated across all PLO aggregates
-      let took = 0;
-      let passed = 0;
-      plos.forEach((p) => {
-        const a = p.aggregate || {};
-        if (a.students_took) {
-          took += a.students_took;
-          passed += a.students_passed || 0;
-        }
-      });
-      if (took > 0) {
-        set(
-          this._el.statOverallPassRate,
-          `${Math.round((passed / took) * 100)}%`,
-        );
-      } else {
-        set(this._el.statOverallPassRate, "—");
-      }
-
-      const status = data.mapping_status || "none";
-      const label = {
-        published: "Published",
-        draft: "Draft",
-        none: "Not mapped",
-      }[status];
-      set(this._el.statMappingStatus, label || status);
     },
 
     // ===================================================================

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -350,24 +350,46 @@
             badge.textContent = `v${data.mapping.version}`;
             heading.appendChild(badge);
           }
-          container.appendChild(heading);
+          // Collapsible program section
+          const section = document.createElement("div");
+          section.className = "plo-program-section";
+
+          // Add toggle chevron to heading
+          const toggle = document.createElement("span");
+          toggle.className = "plo-program-toggle";
+          toggle.innerHTML = '<i class="fas fa-chevron-down"></i>';
+          heading.insertBefore(toggle, heading.firstChild);
+          heading.style.cursor = "pointer";
+          section.appendChild(heading);
+
+          // Content container (collapsible)
+          const content = document.createElement("div");
+          content.className = "plo-program-content";
 
           // Render tree for this program
           if (data.plos && data.plos.length > 0) {
-            container.appendChild(this._buildSummaryBar(data.plos));
+            content.appendChild(this._buildSummaryBar(data.plos));
             const ul = document.createElement("ul");
             ul.className = "plo-tree";
             const savedTree = this.tree;
             this.tree = data;
             data.plos.forEach((plo) => ul.appendChild(this._buildPloNode(plo)));
             this.tree = savedTree;
-            container.appendChild(ul);
+            content.appendChild(ul);
           } else {
             const empty = document.createElement("p");
             empty.className = "text-muted small fst-italic ms-3 mb-3";
             empty.textContent = "No PLOs defined.";
-            container.appendChild(empty);
+            content.appendChild(empty);
           }
+
+          section.appendChild(content);
+          container.appendChild(section);
+
+          // Wire toggle
+          heading.addEventListener("click", () => {
+            section.classList.toggle("collapsed");
+          });
         } catch (_) {
           // skip programs that fail to load
         }
@@ -475,32 +497,51 @@
       if (!plos || plos.length === 0) return bar;
 
       const threshold = 70;
-      let satisfactory = 0;
-      let unsatisfactory = 0;
-      let nodata = 0;
+      const groups = { pass: [], fail: [], nodata: [] };
       plos.forEach((plo) => {
         const rate = plo.aggregate && plo.aggregate.pass_rate;
-        if (rate === null || rate === undefined) nodata++;
-        else if (rate >= threshold) satisfactory++;
-        else unsatisfactory++;
+        if (rate === null || rate === undefined) groups.nodata.push(plo);
+        else if (rate >= threshold) groups.pass.push(plo);
+        else groups.fail.push(plo);
       });
       const total = plos.length;
 
-      // Stats text
-      const stats = document.createElement("div");
-      stats.className = "plo-summary-stats";
-      const addStat = (count, label, cls) => {
-        if (count === 0) return;
-        const span = document.createElement("span");
-        span.className = "plo-summary-stat " + cls;
-        span.innerHTML =
-          '<span class="plo-summary-dot"></span>' + count + " " + label;
-        stats.appendChild(span);
+      // Category rows with sparkline slots
+      const addRow = (label, cls, ploList) => {
+        if (ploList.length === 0) return;
+        const row = document.createElement("div");
+        row.className = "plo-summary-row " + cls;
+
+        const stat = document.createElement("span");
+        stat.className = "plo-summary-stat";
+        stat.innerHTML =
+          '<span class="plo-summary-dot"></span>' +
+          ploList.length +
+          " " +
+          label;
+        row.appendChild(stat);
+
+        // Sparkline slots (populated after trend data loads)
+        const sparkGroup = document.createElement("div");
+        sparkGroup.className = "plo-summary-sparkline-group";
+        ploList.forEach((plo) => {
+          const slot = document.createElement("span");
+          slot.className = "plo-summary-sparkline-slot";
+          slot.dataset.ploId = plo.id;
+          const slotLabel = document.createElement("span");
+          slotLabel.className = "plo-summary-sparkline-label";
+          slotLabel.textContent =
+            plo.plo_number != null ? "(" + plo.plo_number + ")" : "";
+          slot.appendChild(slotLabel);
+          sparkGroup.appendChild(slot);
+        });
+        row.appendChild(sparkGroup);
+
+        bar.appendChild(row);
       };
-      addStat(satisfactory, "satisfactory", "stat-pass");
-      addStat(unsatisfactory, "needs attention", "stat-fail");
-      addStat(nodata, "no data", "stat-nodata");
-      bar.appendChild(stats);
+      addRow("satisfactory", "stat-pass", groups.pass);
+      addRow("needs attention", "stat-fail", groups.fail);
+      addRow("no data", "stat-nodata", groups.nodata);
 
       // Progress bar
       const progress = document.createElement("div");
@@ -512,9 +553,9 @@
         seg.style.width = (count / total) * 100 + "%";
         progress.appendChild(seg);
       };
-      addSegment(satisfactory, "seg-pass");
-      addSegment(unsatisfactory, "seg-fail");
-      addSegment(nodata, "seg-nodata");
+      addSegment(groups.pass.length, "seg-pass");
+      addSegment(groups.fail.length, "seg-fail");
+      addSegment(groups.nodata.length, "seg-nodata");
       bar.appendChild(progress);
 
       return bar;

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -320,79 +320,96 @@
 
     /**
      * Load and render PLO trees for every program (bird's-eye view).
+     * Uses parallel fetches with a generation counter to prevent stale results.
      */
     async _loadAllPrograms() {
       const container = this._el.treeContainer;
       if (!container) return;
       container.innerHTML = "";
 
+      // Generation counter prevents stale results from overwriting a newer load
+      this._allProgramsGen = (this._allProgramsGen || 0) + 1;
+      const gen = this._allProgramsGen;
+
       const qs = new URLSearchParams();
       if (this.currentTermId) qs.set("term_id", this.currentTermId);
 
-      for (const prog of this.programs) {
+      // Fetch all programs in parallel
+      const fetches = this.programs.map((prog) => {
         const progId = prog.program_id || prog.id;
         const url = `/api/programs/${encodeURIComponent(progId)}/plo-dashboard?${qs}`;
-        try {
-          const resp = await fetch(url, {
-            credentials: "include",
-            headers: { Accept: "application/json" },
-          });
-          if (!resp.ok) continue;
-          const data = await resp.json();
+        return fetch(url, {
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        })
+          .then((resp) => (resp.ok ? resp.json() : null))
+          .then((data) => ({ prog, data }))
+          .catch(() => ({ prog, data: null }));
+      });
 
-          // Program section heading
-          const heading = document.createElement("h5");
-          heading.className = "mt-3 mb-2 plo-all-programs-heading";
-          heading.textContent = prog.name;
-          if (data.mapping && data.mapping.version) {
-            const badge = document.createElement("span");
-            badge.className = "badge bg-secondary ms-2";
-            badge.textContent = `v${data.mapping.version}`;
-            heading.appendChild(badge);
-          }
-          // Collapsible program section
-          const section = document.createElement("div");
-          section.className = "plo-program-section";
+      const results = await Promise.allSettled(fetches);
 
-          // Add toggle chevron to heading
-          const toggle = document.createElement("span");
-          toggle.className = "plo-program-toggle";
-          toggle.innerHTML = '<i class="fas fa-chevron-down"></i>';
-          heading.insertBefore(toggle, heading.firstChild);
-          heading.style.cursor = "pointer";
-          section.appendChild(heading);
+      // Abort if a newer load has started
+      if (gen !== this._allProgramsGen) return;
 
-          // Content container (collapsible)
-          const content = document.createElement("div");
-          content.className = "plo-program-content";
+      for (const result of results) {
+        const { prog, data } =
+          result.status === "fulfilled" ? result.value : {};
+        if (!data) continue;
 
-          // Render tree for this program
-          if (data.plos && data.plos.length > 0) {
-            content.appendChild(this._buildSummaryBar(data.plos));
-            const ul = document.createElement("ul");
-            ul.className = "plo-tree";
-            const savedTree = this.tree;
-            this.tree = data;
-            data.plos.forEach((plo) => ul.appendChild(this._buildPloNode(plo)));
-            this.tree = savedTree;
-            content.appendChild(ul);
-          } else {
-            const empty = document.createElement("p");
-            empty.className = "text-muted small fst-italic ms-3 mb-3";
-            empty.textContent = "No PLOs defined.";
-            content.appendChild(empty);
-          }
-
-          section.appendChild(content);
-          container.appendChild(section);
-
-          // Wire toggle
-          heading.addEventListener("click", () => {
-            section.classList.toggle("collapsed");
-          });
-        } catch (_) {
-          // skip programs that fail to load
+        // Program section heading
+        const heading = document.createElement("h5");
+        heading.className = "mt-3 mb-2 plo-all-programs-heading";
+        heading.textContent = prog.name;
+        if (data.mapping && data.mapping.version) {
+          const badge = document.createElement("span");
+          badge.className = "badge bg-secondary ms-2";
+          badge.textContent = `v${data.mapping.version}`;
+          heading.appendChild(badge);
         }
+        // Collapsible program section
+        const section = document.createElement("div");
+        section.className = "plo-program-section";
+
+        // Add toggle chevron to heading
+        const toggle = document.createElement("span");
+        toggle.className = "plo-program-toggle";
+        toggle.innerHTML = '<i class="fas fa-chevron-down"></i>';
+        heading.insertBefore(toggle, heading.firstChild);
+        heading.style.cursor = "pointer";
+        section.appendChild(heading);
+
+        // Content container (collapsible)
+        const content = document.createElement("div");
+        content.className = "plo-program-content";
+
+        // Render tree for this program
+        if (data.plos && data.plos.length > 0) {
+          content.appendChild(this._buildSummaryBar(data.plos));
+          const ul = document.createElement("ul");
+          ul.className = "plo-tree";
+          const savedTree = this.tree;
+          const savedDisplayMode = this.displayMode;
+          this.tree = data;
+          this.displayMode = data.assessment_display_mode || "both";
+          data.plos.forEach((plo) => ul.appendChild(this._buildPloNode(plo)));
+          this.tree = savedTree;
+          this.displayMode = savedDisplayMode;
+          content.appendChild(ul);
+        } else {
+          const empty = document.createElement("p");
+          empty.className = "text-muted small fst-italic ms-3 mb-3";
+          empty.textContent = "No PLOs defined.";
+          content.appendChild(empty);
+        }
+
+        section.appendChild(content);
+        container.appendChild(section);
+
+        // Wire toggle
+        heading.addEventListener("click", () => {
+          section.classList.toggle("collapsed");
+        });
       }
 
       // Load trend sparklines for each program
@@ -520,9 +537,7 @@
         const dot = document.createElement("span");
         dot.className = "plo-summary-dot";
         stat.appendChild(dot);
-        stat.appendChild(
-          document.createTextNode(ploList.length + " " + label),
-        );
+        stat.appendChild(document.createTextNode(ploList.length + " " + label));
         row.appendChild(stat);
 
         // Sparkline slots (populated after trend data loads)

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -517,11 +517,12 @@
 
         const stat = document.createElement("span");
         stat.className = "plo-summary-stat";
-        stat.innerHTML =
-          '<span class="plo-summary-dot"></span>' +
-          ploList.length +
-          " " +
-          label;
+        const dot = document.createElement("span");
+        dot.className = "plo-summary-dot";
+        stat.appendChild(dot);
+        stat.appendChild(
+          document.createTextNode(ploList.length + " " + label),
+        );
         row.appendChild(stat);
 
         // Sparkline slots (populated after trend data loads)

--- a/static/plo_dashboard.js
+++ b/static/plo_dashboard.js
@@ -224,6 +224,7 @@
       }
       sel.value = initial;
       this.currentProgramId = initial;
+      this._updateProgramActions();
     },
 
     async _loadTerms() {

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -85,6 +85,11 @@
 
     const threshold = (opts && opts.threshold) || 70;
 
+    // Per-point colour: red for below threshold, blue for at/above
+    const pointColors = data.map((d) =>
+      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
+    );
+
     // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
     const lineColor =
@@ -109,7 +114,7 @@
               tension: 0.3,
               pointRadius: pointRadii,
               pointStyle: pointStyles,
-              pointBackgroundColor: lineColor,
+              pointBackgroundColor: pointColors,
               borderWidth: 1.5,
               spanGaps: true,
               segment: {
@@ -187,6 +192,18 @@
     const panel = document.createElement("div");
     panel.className = "plo-trend-panel";
 
+    // Close button
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "plo-trend-panel-close";
+    closeBtn.innerHTML = "&times;";
+    closeBtn.title = "Close trend chart";
+    closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      panel.remove();
+    });
+    panel.appendChild(closeBtn);
+
     const canvas = document.createElement("canvas");
     canvas.style.width = "100%";
     canvas.style.height = "200px";
@@ -212,7 +229,12 @@
       terms.map((t, i) => (t.is_current ? i : -1)).filter((i) => i >= 0),
     );
 
-    // Determine line colour
+    // Per-point colour: red for below threshold, blue for at/above
+    const pointColors = data.map((d) =>
+      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
+    );
+
+    // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
     const lineColor =
       lastValid.length > 0 && lastValid[lastValid.length - 1] < threshold
@@ -236,7 +258,7 @@
               tension: 0.3,
               pointRadius: 4,
               pointHoverRadius: 6,
-              pointBackgroundColor: lineColor,
+              pointBackgroundColor: pointColors,
               borderWidth: 2,
               spanGaps: true,
               segment: {

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -25,7 +25,12 @@
 
   /**
    * Determine trend direction from an array of data points.
-   * Returns: "up" | "down" | "flat" | "none"
+   * Returns: "strong-up" | "up" | "flat" | "down" | "strong-down" | "none"
+   *
+   * Thresholds (percentage-point change):
+   *   |diff| < 2  → flat
+   *   2 ≤ diff < 10 → up / down
+   *   diff ≥ 10     → strong-up / strong-down
    */
   function getTrendDirection(trendPoints) {
     // Filter to only non-null points
@@ -37,7 +42,10 @@
     const diff = last - first;
 
     if (Math.abs(diff) < 2) return "flat";
-    return diff > 0 ? "up" : "down";
+    if (diff >= 10) return "strong-up";
+    if (diff > 0) return "up";
+    if (diff <= -10) return "strong-down";
+    return "down";
   }
 
   /**
@@ -45,10 +53,14 @@
    */
   function getTrendArrow(direction) {
     switch (direction) {
+      case "strong-up":
+        return { arrow: "⬆", cssClass: "trend-strong-up" };
       case "up":
         return { arrow: "↑", cssClass: "trend-up" };
       case "down":
         return { arrow: "↓", cssClass: "trend-down" };
+      case "strong-down":
+        return { arrow: "⬇", cssClass: "trend-strong-down" };
       case "flat":
         return { arrow: "→", cssClass: "trend-flat" };
       default:
@@ -113,16 +125,21 @@
     requestAnimationFrame(() => {
       if (typeof Chart === "undefined") return;
 
-      // Build gradient fill from lineColor
+      // Build gradient fills (blue above threshold, red below)
       const ctx2d = canvas.getContext("2d");
-      let gradientFill = lineColor;
+      const blueRgb = "13, 110, 253";
+      const redRgb = "220, 53, 69";
+      let gradientFillBlue = `rgba(${blueRgb}, ${TREND_FILL_ALPHA_TOP})`;
+      let gradientFillRed = `rgba(${redRgb}, ${TREND_FILL_ALPHA_TOP})`;
       if (ctx2d) {
-        const grd = ctx2d.createLinearGradient(0, 0, 0, SPARK_HEIGHT);
-        const baseRgb =
-          lineColor === TREND_LINE_COLOR_FAIL ? "220, 53, 69" : "13, 110, 253";
-        grd.addColorStop(0, `rgba(${baseRgb}, ${TREND_FILL_ALPHA_TOP})`);
-        grd.addColorStop(1, `rgba(${baseRgb}, ${TREND_FILL_ALPHA_BOTTOM})`);
-        gradientFill = grd;
+        const grdB = ctx2d.createLinearGradient(0, 0, 0, SPARK_HEIGHT);
+        grdB.addColorStop(0, `rgba(${blueRgb}, ${TREND_FILL_ALPHA_TOP})`);
+        grdB.addColorStop(1, `rgba(${blueRgb}, ${TREND_FILL_ALPHA_BOTTOM})`);
+        gradientFillBlue = grdB;
+        const grdR = ctx2d.createLinearGradient(0, 0, 0, SPARK_HEIGHT);
+        grdR.addColorStop(0, `rgba(${redRgb}, ${TREND_FILL_ALPHA_TOP})`);
+        grdR.addColorStop(1, `rgba(${redRgb}, ${TREND_FILL_ALPHA_BOTTOM})`);
+        gradientFillRed = grdR;
       }
 
       new Chart(canvas, {
@@ -133,7 +150,7 @@
             {
               data,
               borderColor: lineColor,
-              backgroundColor: gradientFill,
+              backgroundColor: gradientFillBlue,
               fill: true,
               tension: 0.4,
               pointRadius: pointRadii,
@@ -149,6 +166,19 @@
                   currentTermIndices.has(ctx.p1DataIndex)
                     ? TREND_NULL_DASH
                     : undefined,
+                borderColor: (ctx) => {
+                  // Red segment when both endpoints are below threshold
+                  const p0 = ctx.p0.parsed.y;
+                  const p1 = ctx.p1.parsed.y;
+                  if (
+                    !isNaN(p0) &&
+                    !isNaN(p1) &&
+                    p0 < threshold &&
+                    p1 < threshold
+                  )
+                    return TREND_LINE_COLOR_FAIL;
+                  return undefined;
+                },
               },
             },
           ],
@@ -173,6 +203,51 @@
           },
         },
         plugins: [
+          {
+            id: "belowThresholdFill",
+            afterDatasetsDraw(chart) {
+              const ds = chart.data.datasets[0];
+              if (!ds) return;
+              const meta = chart.getDatasetMeta(0);
+              const yScale = chart.scales.y;
+              if (!yScale || meta.data.length < 2) return;
+
+              const threshY = yScale.getPixelForValue(threshold);
+              const { left, right, bottom } = chart.chartArea;
+              const ctx = chart.ctx;
+              ctx.save();
+              ctx.beginPath();
+              let started = false;
+              for (let i = 0; i < meta.data.length; i++) {
+                const pt = meta.data[i];
+                const val = ds.data[i];
+                if (val === null || val === undefined || isNaN(val)) continue;
+                const px = pt.x;
+                const py = Math.max(pt.y, threshY);
+                if (!started) {
+                  ctx.moveTo(px, py);
+                  started = true;
+                } else {
+                  ctx.lineTo(px, py);
+                }
+              }
+              if (!started) {
+                ctx.restore();
+                return;
+              }
+              ctx.lineTo(right, bottom);
+              ctx.lineTo(left, bottom);
+              ctx.closePath();
+              ctx.clip();
+              if (typeof gradientFillRed === "object") {
+                ctx.fillStyle = gradientFillRed;
+              } else {
+                ctx.fillStyle = `rgba(220, 53, 69, ${TREND_FILL_ALPHA_TOP})`;
+              }
+              ctx.fillRect(left, threshY, right - left, bottom - threshY);
+              ctx.restore();
+            },
+          },
           {
             id: "thresholdLine",
             afterDraw(chart) {
@@ -796,12 +871,44 @@
         const plo = (plos || []).find((p) => String(p.id) === String(ploId));
         if (!plo || !plo.trend || plo.trend.length < 2) return;
 
-        // Remove existing sparkline if re-injecting
+        // Remove existing sparkline / badge if re-injecting
         const existing = slot.querySelector(".plo-sparkline");
         if (existing) existing.remove();
+        const existingBadge = slot.querySelector(".plo-trend-indicator");
+        if (existingBadge) existingBadge.remove();
 
-        const canvas = createSparkline(plo.trend, terms, { threshold: 70 });
+        const canvas = createSparkline(plo.trend, terms, {
+          threshold: 70,
+          discontinuities: plo.discontinuities || [],
+        });
         slot.insertBefore(canvas, slot.firstChild);
+
+        // Add compact trend badge (arrow + delta) after the sparkline
+        const direction = getTrendDirection(plo.trend);
+        const { arrow, cssClass } = getTrendArrow(direction);
+        const delta = getTrendDelta(plo.trend);
+        if (arrow) {
+          const badge = document.createElement("span");
+          badge.className = "plo-trend-indicator plo-trend-indicator--mini";
+          if (cssClass) badge.classList.add(cssClass);
+          const arrowEl = document.createElement("span");
+          arrowEl.className = "plo-trend-arrow " + cssClass;
+          arrowEl.textContent = arrow;
+          badge.appendChild(arrowEl);
+          if (delta !== null) {
+            const deltaEl = document.createElement("span");
+            deltaEl.className = "plo-trend-delta";
+            deltaEl.textContent = (delta >= 0 ? "+" : "") + delta + "%";
+            badge.appendChild(deltaEl);
+          }
+          // Insert badge after sparkline, before the label
+          const label = slot.querySelector(".plo-summary-sparkline-label");
+          if (label) {
+            slot.insertBefore(badge, label);
+          } else {
+            slot.appendChild(badge);
+          }
+        }
 
         // Click opens trend panel below the row
         canvas.addEventListener("click", (e) => {

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -786,6 +786,69 @@
           }
         });
       });
+
+      // Populate summary bar sparklines
+      this._injectSummarySparklines(container, plos, terms);
+    },
+
+    /**
+     * Inject sparkline canvases into summary bar sparkline slots.
+     * Each slot is tagged with data-plo-id matching a PLO in the trend data.
+     * Clicking a sparkline toggles a full trend panel below the category row.
+     */
+    _injectSummarySparklines(container, plos, terms) {
+      const slots = container.querySelectorAll(".plo-summary-sparkline-slot");
+      slots.forEach((slot) => {
+        const ploId = slot.dataset.ploId;
+        const plo = (plos || []).find((p) => String(p.id) === String(ploId));
+        if (!plo || !plo.trend || plo.trend.length < 2) return;
+
+        // Remove existing sparkline if re-injecting
+        const existing = slot.querySelector(".plo-sparkline");
+        if (existing) existing.remove();
+
+        const canvas = createSparkline(plo.trend, terms, { threshold: 70 });
+        slot.insertBefore(canvas, slot.firstChild);
+
+        // Click opens trend panel below the row
+        canvas.addEventListener("click", (e) => {
+          e.stopPropagation();
+          this._toggleSummaryTrendPanel(slot, plo, terms);
+        });
+      });
+    },
+
+    /**
+     * Toggle a trend chart panel below the summary row containing the clicked sparkline.
+     */
+    _toggleSummaryTrendPanel(slot, plo, terms) {
+      const row = slot.closest(".plo-summary-row");
+      if (!row) return;
+
+      // Check if this PLO's panel is already open
+      const next = row.nextElementSibling;
+      if (
+        next &&
+        next.classList.contains("plo-trend-panel") &&
+        next.dataset.ploId === String(plo.id)
+      ) {
+        next.remove();
+        return;
+      }
+
+      // Remove any other open panel in this summary bar
+      const bar = slot.closest(".plo-summary-bar");
+      if (bar) {
+        bar.querySelectorAll(".plo-trend-panel").forEach((p) => p.remove());
+      }
+
+      const panel = createTrendPanel(plo.trend, terms, {
+        title: "PLO-" + plo.plo_number + ": " + plo.description,
+        clos: plo.clos || [],
+        discontinuities: plo.discontinuities || [],
+      });
+      panel.dataset.ploId = String(plo.id);
+      row.after(panel);
     },
 
     /**

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -13,10 +13,12 @@
   "use strict";
 
   // Chart.js defaults for sparklines
-  const SPARK_WIDTH = 90;
-  const SPARK_HEIGHT = 28;
+  const SPARK_WIDTH = 100;
+  const SPARK_HEIGHT = 32;
   const TREND_LINE_COLOR = "#0d6efd";
   const TREND_LINE_COLOR_FAIL = "#dc3545";
+  const TREND_FILL_ALPHA_TOP = 0.18;
+  const TREND_FILL_ALPHA_BOTTOM = 0.02;
   const TREND_FILL_COLOR = "rgba(13, 110, 253, 0.08)";
   const TREND_NULL_DASH = [4, 4];
   const THRESHOLD_LINE_COLOR = "rgba(108, 117, 125, 0.3)";
@@ -87,27 +89,12 @@
       p !== null && p.pass_rate !== null ? p.pass_rate : NaN,
     );
 
-    // Detect which points are from "current" (in-progress) terms
-    const pointStyles = terms.map((t) => (t.is_current ? "rectRot" : "circle"));
-    const pointRadii = terms.map((t) => (t.is_current ? 3 : 2));
     // Use a segment-based approach for dashed lines at in-progress terms
     const currentTermIndices = new Set(
       terms.map((t, i) => (t.is_current ? i : -1)).filter((i) => i >= 0),
     );
 
     const threshold = (opts && opts.threshold) || 70;
-
-    // Per-point colour: red for below threshold, blue for at/above
-    const pointColors = data.map((d) =>
-      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
-    );
-    // Larger radius for fail points so they stand out
-    const failRadii = data.map((d, i) =>
-      !isNaN(d) && d < threshold ? Math.max(pointRadii[i], 4) : pointRadii[i],
-    );
-    const pointBorders = data.map((d) =>
-      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
-    );
 
     // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
@@ -116,9 +103,27 @@
         ? TREND_LINE_COLOR_FAIL
         : TREND_LINE_COLOR;
 
+    // Only show endpoint dot (last valid point)
+    const lastValidIdx = data.reduce((acc, d, i) => (!isNaN(d) ? i : acc), -1);
+    const pointRadii = data.map((_, i) => (i === lastValidIdx ? 3 : 0));
+    const pointColors = data.map(() => lineColor);
+    const pointBorders = pointColors;
+
     // Defer rendering until canvas is in the DOM
     requestAnimationFrame(() => {
       if (typeof Chart === "undefined") return;
+
+      // Build gradient fill from lineColor
+      const ctx2d = canvas.getContext("2d");
+      let gradientFill = lineColor;
+      if (ctx2d) {
+        const grd = ctx2d.createLinearGradient(0, 0, 0, SPARK_HEIGHT);
+        const baseRgb =
+          lineColor === TREND_LINE_COLOR_FAIL ? "220, 53, 69" : "13, 110, 253";
+        grd.addColorStop(0, `rgba(${baseRgb}, ${TREND_FILL_ALPHA_TOP})`);
+        grd.addColorStop(1, `rgba(${baseRgb}, ${TREND_FILL_ALPHA_BOTTOM})`);
+        gradientFill = grd;
+      }
 
       new Chart(canvas, {
         type: "line",
@@ -128,15 +133,16 @@
             {
               data,
               borderColor: lineColor,
-              backgroundColor: TREND_FILL_COLOR,
+              backgroundColor: gradientFill,
               fill: true,
-              tension: 0.3,
-              pointRadius: failRadii,
-              pointStyle: pointStyles,
+              tension: 0.4,
+              pointRadius: pointRadii,
               pointBackgroundColor: pointColors,
               pointBorderColor: pointBorders,
-              pointBorderWidth: 1,
-              borderWidth: 1.5,
+              pointBorderWidth: 1.5,
+              borderWidth: 2,
+              borderCapStyle: "round",
+              borderJoinStyle: "round",
               spanGaps: true,
               segment: {
                 borderDash: (ctx) =>
@@ -151,18 +157,10 @@
           responsive: false,
           maintainAspectRatio: false,
           animation: false,
+          events: [], // Disable all hover/tooltip — click handled via DOM
           plugins: {
             legend: { display: false },
-            tooltip: {
-              enabled: true,
-              callbacks: {
-                title: (items) => items[0]?.label || "",
-                label: (item) =>
-                  item.raw !== null && !isNaN(item.raw)
-                    ? `${Math.round(item.raw)}%`
-                    : "No data",
-              },
-            },
+            tooltip: { enabled: false },
             annotation: undefined,
           },
           scales: {
@@ -171,12 +169,7 @@
               display: false,
               min: 0,
               max: 100,
-              // Threshold reference line via afterDraw plugin
             },
-          },
-          interaction: {
-            mode: "index",
-            intersect: false,
           },
         },
         plugins: [

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -25,6 +25,21 @@
   const THRESHOLD_LINE_COLOR = "rgba(108, 117, 125, 0.3)";
 
   /**
+   * Destroy any Chart.js instances attached to canvas elements within an element.
+   * Must be called before removing DOM elements to avoid memory leaks.
+   */
+  function _destroyCharts(el) {
+    if (typeof Chart === "undefined" || typeof Chart.getChart !== "function")
+      return;
+    el.querySelectorAll("canvas").forEach(function (canvas) {
+      var chart = Chart.getChart(canvas);
+      if (chart && typeof chart.destroy === "function") {
+        chart.destroy();
+      }
+    });
+  }
+
+  /**
    * Determine trend direction from an array of data points.
    * Returns: "strong-up" | "up" | "flat" | "down" | "strong-down" | "none"
    *
@@ -827,18 +842,24 @@
       if (!programId) return;
       if (selectedTermId !== undefined) this.selectedTermId = selectedTermId;
 
+      // Track the latest request to ignore stale responses
+      const gen = (this._loadTrendGen = (this._loadTrendGen || 0) + 1);
+
       const url = `/api/programs/${encodeURIComponent(programId)}/plo-dashboard/trend`;
       try {
         const resp = await fetch(url, {
           credentials: "include",
           headers: { Accept: "application/json" },
         });
+        if (gen !== this._loadTrendGen) return; // stale response
         if (!resp.ok) return;
         const data = await resp.json();
+        if (gen !== this._loadTrendGen) return; // stale response
         if (!data.success) return;
         this.trendData = data;
         this.injectSparklines();
       } catch (err) {
+        if (gen !== this._loadTrendGen) return;
         console.warn("PloTrend: failed to load trend data", err);
       }
     },
@@ -871,7 +892,10 @@
             .querySelectorAll(
               ":scope > .plo-tree-header .plo-trend-indicator, :scope > .plo-trend-panel",
             )
-            .forEach((el) => el.remove());
+            .forEach((el) => {
+              _destroyCharts(el);
+              el.remove();
+            });
           this._injectIntoNode(ploNode, plo.trend, terms, {
             title: `PLO-${plo.plo_number}: ${plo.description}`,
             clos: plo.clos || [],
@@ -890,7 +914,10 @@
               .querySelectorAll(
                 ":scope > .plo-tree-header .plo-trend-indicator, :scope > .plo-trend-panel",
               )
-              .forEach((el) => el.remove());
+              .forEach((el) => {
+                _destroyCharts(el);
+                el.remove();
+              });
             this._injectIntoNode(cloNode, clo.trend, terms, {
               title: `${clo.course_number || ""} CLO ${clo.clo_number || "?"}: ${clo.description || ""}`,
               discontinuities: plo.discontinuities || [],
@@ -918,7 +945,10 @@
 
         // Remove existing sparkline / badge if re-injecting
         const existing = slot.querySelector(".plo-sparkline");
-        if (existing) existing.remove();
+        if (existing) {
+          _destroyCharts(existing.parentElement || existing);
+          existing.remove();
+        }
         const existingBadge = slot.querySelector(".plo-trend-indicator");
         if (existingBadge) existingBadge.remove();
 
@@ -963,10 +993,23 @@
           }
         }
 
-        // Click opens trend panel below the row
+        // Click / keyboard opens trend panel below the row
+        canvas.setAttribute("tabindex", "0");
+        canvas.setAttribute("role", "button");
+        canvas.setAttribute(
+          "aria-label",
+          "View trend chart for PLO-" + plo.plo_number,
+        );
         canvas.addEventListener("click", (e) => {
           e.stopPropagation();
           this._toggleSummaryTrendPanel(slot, plo, terms);
+        });
+        canvas.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            this._toggleSummaryTrendPanel(slot, plo, terms);
+          }
         });
       });
     },
@@ -985,6 +1028,7 @@
         next.classList.contains("plo-trend-panel") &&
         next.dataset.ploId === String(plo.id)
       ) {
+        _destroyCharts(next);
         next.remove();
         return;
       }
@@ -992,7 +1036,10 @@
       // Remove any other open panel in this summary bar
       const bar = slot.closest(".plo-summary-bar");
       if (bar) {
-        bar.querySelectorAll(".plo-trend-panel").forEach((p) => p.remove());
+        bar.querySelectorAll(".plo-trend-panel").forEach((p) => {
+          _destroyCharts(p);
+          p.remove();
+        });
       }
 
       const panel = createTrendPanel(plo.trend, terms, {
@@ -1055,10 +1102,19 @@
         meta.insertBefore(wrap, meta.firstChild);
       }
 
-      // Click handler for drill-down panel
+      // Click / keyboard handler for drill-down panel
+      wrap.setAttribute("tabindex", "0");
+      wrap.setAttribute("role", "button");
       wrap.addEventListener("click", (e) => {
         e.stopPropagation();
         this._toggleTrendPanel(nodeEl, trendPoints, terms, opts);
+      });
+      wrap.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          this._toggleTrendPanel(nodeEl, trendPoints, terms, opts);
+        }
       });
     },
 
@@ -1066,6 +1122,7 @@
       // Check if panel already exists
       const existing = nodeEl.querySelector(".plo-trend-panel");
       if (existing) {
+        _destroyCharts(existing);
         existing.remove();
         return;
       }

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -440,7 +440,6 @@
           pointBackgroundColor: color,
           pointBorderColor: color,
           borderWidth: 1.5,
-          borderDash: [4, 3],
           spanGaps: true,
           order: 1, // behind PLO line
         });
@@ -697,15 +696,17 @@
       const container = document.getElementById("ploTreeContainer");
       if (!container) return;
 
-      // Remove any previously injected sparklines
-      container
-        .querySelectorAll(".plo-sparkline-wrap, .plo-trend-panel")
-        .forEach((el) => el.remove());
-
       (plos || []).forEach((plo) => {
         // Find the PLO node in the DOM
         const ploNode = container.querySelector(`[data-plo-id="${plo.id}"]`);
         if (ploNode) {
+          // Remove existing sparklines/panels for THIS node only (avoids
+          // wiping sparklines from other programs in the All-Programs view)
+          ploNode
+            .querySelectorAll(
+              ":scope > .plo-tree-header .plo-sparkline-wrap, :scope > .plo-trend-panel",
+            )
+            .forEach((el) => el.remove());
           this._injectIntoNode(ploNode, plo.trend, terms, {
             title: `PLO-${plo.plo_number}: ${plo.description}`,
             clos: plo.clos || [],
@@ -719,6 +720,11 @@
             `[data-clo-id="${clo.outcome_id}"]`,
           );
           if (cloNode) {
+            cloNode
+              .querySelectorAll(
+                ":scope > .plo-tree-header .plo-sparkline-wrap, :scope > .plo-trend-panel",
+              )
+              .forEach((el) => el.remove());
             this._injectIntoNode(cloNode, clo.trend, terms, {
               title: `${clo.course_number || ""} CLO ${clo.clo_number || "?"}: ${clo.description || ""}`,
             });

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -17,6 +17,7 @@
   const SPARK_HEIGHT = 32;
   const TREND_LINE_COLOR = "#0d6efd";
   const TREND_LINE_COLOR_FAIL = "#dc3545";
+  const TREND_LINE_COLOR_FUTURE = "rgba(160, 170, 180, 0.45)";
   const TREND_FILL_ALPHA_TOP = 0.18;
   const TREND_FILL_ALPHA_BOTTOM = 0.02;
   const TREND_FILL_COLOR = "rgba(13, 110, 253, 0.08)";
@@ -107,6 +108,13 @@
     );
 
     const threshold = (opts && opts.threshold) || 70;
+    const selectedTermIndex =
+      opts && opts.selectedTermIndex != null && opts.selectedTermIndex >= 0
+        ? opts.selectedTermIndex
+        : -1;
+    // Is there a "future" region after the selected term?
+    const hasFuture =
+      selectedTermIndex >= 0 && selectedTermIndex < data.length - 1;
 
     // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
@@ -115,10 +123,16 @@
         ? TREND_LINE_COLOR_FAIL
         : TREND_LINE_COLOR;
 
-    // Only show endpoint dot (last valid point)
+    // Dot position: selected term if valid, else last valid point
     const lastValidIdx = data.reduce((acc, d, i) => (!isNaN(d) ? i : acc), -1);
-    const pointRadii = data.map((_, i) => (i === lastValidIdx ? 3 : 0));
-    const pointColors = data.map(() => lineColor);
+    const dotIdx =
+      selectedTermIndex >= 0 && !isNaN(data[selectedTermIndex])
+        ? selectedTermIndex
+        : lastValidIdx;
+    const pointRadii = data.map((_, i) => (i === dotIdx ? 3 : 0));
+    const pointColors = data.map((_, i) =>
+      hasFuture && i > selectedTermIndex ? TREND_LINE_COLOR_FUTURE : lineColor,
+    );
     const pointBorders = pointColors;
 
     // Defer rendering until canvas is in the DOM
@@ -167,6 +181,9 @@
                     ? TREND_NULL_DASH
                     : undefined,
                 borderColor: (ctx) => {
+                  // Grey for segments beyond the selected term
+                  if (hasFuture && ctx.p0DataIndex >= selectedTermIndex)
+                    return TREND_LINE_COLOR_FUTURE;
                   // Red segment when both endpoints are below threshold
                   const p0 = ctx.p0.parsed.y;
                   const p1 = ctx.p1.parsed.y;
@@ -290,6 +307,21 @@
                 ctx.stroke();
                 ctx.restore();
               });
+            },
+          },
+          {
+            id: "futureWash",
+            afterDraw(chart) {
+              if (!hasFuture) return;
+              const xScale = chart.scales.x;
+              if (!xScale) return;
+              const xPos = xScale.getPixelForValue(selectedTermIndex);
+              const { top, bottom, right } = chart.chartArea;
+              const ctx = chart.ctx;
+              ctx.save();
+              ctx.fillStyle = "rgba(255, 255, 255, 0.6)";
+              ctx.fillRect(xPos, top, right - xPos, bottom - top);
+              ctx.restore();
             },
           },
         ],
@@ -783,13 +815,17 @@
   // -----------------------------------------------------------------------
   const PloTrend = {
     trendData: null,
+    selectedTermId: null,
 
     /**
      * Fetch trend data for the given program and inject sparklines
      * into the already-rendered PLO tree.
+     * @param {string} programId
+     * @param {string} [selectedTermId] - The currently selected term from the filter
      */
-    async loadTrend(programId) {
+    async loadTrend(programId, selectedTermId) {
       if (!programId) return;
+      if (selectedTermId !== undefined) this.selectedTermId = selectedTermId;
 
       const url = `/api/programs/${encodeURIComponent(programId)}/plo-dashboard/trend`;
       try {
@@ -815,6 +851,13 @@
       const { terms, plos } = this.trendData;
       if (!terms || terms.length < 2) return; // need ≥2 terms for a trend
 
+      // Find which term index the user has selected
+      const selectedTermIndex = this.selectedTermId
+        ? terms.findIndex(
+            (t) => String(t.term_id) === String(this.selectedTermId),
+          )
+        : -1;
+
       const container = document.getElementById("ploTreeContainer");
       if (!container) return;
 
@@ -833,6 +876,7 @@
             title: `PLO-${plo.plo_number}: ${plo.description}`,
             clos: plo.clos || [],
             discontinuities: plo.discontinuities || [],
+            selectedTermIndex,
           });
         }
 
@@ -850,13 +894,14 @@
             this._injectIntoNode(cloNode, clo.trend, terms, {
               title: `${clo.course_number || ""} CLO ${clo.clo_number || "?"}: ${clo.description || ""}`,
               discontinuities: plo.discontinuities || [],
+              selectedTermIndex,
             });
           }
         });
       });
 
       // Populate summary bar sparklines
-      this._injectSummarySparklines(container, plos, terms);
+      this._injectSummarySparklines(container, plos, terms, selectedTermIndex);
     },
 
     /**
@@ -864,7 +909,7 @@
      * Each slot is tagged with data-plo-id matching a PLO in the trend data.
      * Clicking a sparkline toggles a full trend panel below the category row.
      */
-    _injectSummarySparklines(container, plos, terms) {
+    _injectSummarySparklines(container, plos, terms, selectedTermIndex) {
       const slots = container.querySelectorAll(".plo-summary-sparkline-slot");
       slots.forEach((slot) => {
         const ploId = slot.dataset.ploId;
@@ -880,6 +925,7 @@
         const canvas = createSparkline(plo.trend, terms, {
           threshold: 70,
           discontinuities: plo.discontinuities || [],
+          selectedTermIndex: selectedTermIndex != null ? selectedTermIndex : -1,
         });
         slot.insertBefore(canvas, slot.firstChild);
 

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -89,6 +89,13 @@
     const pointColors = data.map((d) =>
       !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
     );
+    // Larger radius for fail points so they stand out
+    const failRadii = data.map((d, i) =>
+      !isNaN(d) && d < threshold ? Math.max(pointRadii[i], 4) : pointRadii[i],
+    );
+    const pointBorders = data.map((d) =>
+      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
+    );
 
     // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
@@ -112,9 +119,11 @@
               backgroundColor: TREND_FILL_COLOR,
               fill: true,
               tension: 0.3,
-              pointRadius: pointRadii,
+              pointRadius: failRadii,
               pointStyle: pointStyles,
               pointBackgroundColor: pointColors,
+              pointBorderColor: pointBorders,
+              pointBorderWidth: 1,
               borderWidth: 1.5,
               spanGaps: true,
               segment: {
@@ -233,6 +242,11 @@
     const pointColors = data.map((d) =>
       !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
     );
+    // Larger radius for fail points
+    const failRadii = data.map((d) => (!isNaN(d) && d < threshold ? 6 : 4));
+    const pointBorders = data.map((d) =>
+      !isNaN(d) && d < threshold ? TREND_LINE_COLOR_FAIL : TREND_LINE_COLOR,
+    );
 
     // Determine line colour based on latest valid point
     const lastValid = data.filter((d) => !isNaN(d));
@@ -256,9 +270,11 @@
               backgroundColor: TREND_FILL_COLOR,
               fill: true,
               tension: 0.3,
-              pointRadius: 4,
+              pointRadius: failRadii,
               pointHoverRadius: 6,
               pointBackgroundColor: pointColors,
+              pointBorderColor: pointBorders,
+              pointBorderWidth: 1.5,
               borderWidth: 2,
               spanGaps: true,
               segment: {

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -55,6 +55,18 @@
   }
 
   /**
+   * Compute percentage-point change between first and last valid data points.
+   * Returns an integer delta, or null if insufficient data.
+   */
+  function getTrendDelta(trendPoints) {
+    const valid = (trendPoints || []).filter(
+      (p) => p !== null && p.pass_rate !== null,
+    );
+    if (valid.length < 2) return null;
+    return Math.round(valid[valid.length - 1].pass_rate - valid[0].pass_rate);
+  }
+
+  /**
    * Create a tiny sparkline canvas element from trend data points.
    * Returns an HTMLCanvasElement ready to insert into the DOM.
    */
@@ -742,11 +754,11 @@
         // Find the PLO node in the DOM
         const ploNode = container.querySelector(`[data-plo-id="${plo.id}"]`);
         if (ploNode) {
-          // Remove existing sparklines/panels for THIS node only (avoids
-          // wiping sparklines from other programs in the All-Programs view)
+          // Remove existing trend indicators/panels for THIS node only (avoids
+          // wiping indicators from other programs in the All-Programs view)
           ploNode
             .querySelectorAll(
-              ":scope > .plo-tree-header .plo-sparkline-wrap, :scope > .plo-trend-panel",
+              ":scope > .plo-tree-header .plo-trend-indicator, :scope > .plo-trend-panel",
             )
             .forEach((el) => el.remove());
           this._injectIntoNode(ploNode, plo.trend, terms, {
@@ -764,7 +776,7 @@
           if (cloNode) {
             cloNode
               .querySelectorAll(
-                ":scope > .plo-tree-header .plo-sparkline-wrap, :scope > .plo-trend-panel",
+                ":scope > .plo-tree-header .plo-trend-indicator, :scope > .plo-trend-panel",
               )
               .forEach((el) => el.remove());
             this._injectIntoNode(cloNode, clo.trend, terms, {
@@ -777,8 +789,11 @@
     },
 
     /**
-     * Inject a sparkline + trend arrow into a tree node's meta area,
+     * Inject a compact trend indicator into a tree node's meta area,
      * and wire a click handler to toggle a full trend chart panel.
+     *
+     * The indicator replaces the previous sparkline with an immediately
+     * readable badge: arrow + percentage-point change (e.g. "↑ +8%").
      */
     _injectIntoNode(nodeEl, trendPoints, terms, opts) {
       if (!trendPoints || trendPoints.length < 2) return;
@@ -788,23 +803,30 @@
       const meta = header.querySelector(".plo-tree-meta");
       if (!meta) return;
 
-      // Trend direction arrow
+      // Trend direction + delta
       const direction = getTrendDirection(trendPoints);
       const { arrow, cssClass } = getTrendArrow(direction);
+      const delta = getTrendDelta(trendPoints);
 
-      // Wrap sparkline + arrow
+      // Build compact trend indicator
       const wrap = document.createElement("span");
-      wrap.className = "plo-sparkline-wrap";
+      wrap.className = "plo-trend-indicator";
+      if (cssClass) wrap.classList.add(cssClass);
+      wrap.title = "Click to view trend chart";
 
       if (arrow) {
         const arrowEl = document.createElement("span");
-        arrowEl.className = `plo-trend-arrow ${cssClass}`;
+        arrowEl.className = "plo-trend-arrow " + cssClass;
         arrowEl.textContent = arrow;
         wrap.appendChild(arrowEl);
       }
 
-      const sparkCanvas = createSparkline(trendPoints, terms, opts);
-      wrap.appendChild(sparkCanvas);
+      if (delta !== null) {
+        const deltaEl = document.createElement("span");
+        deltaEl.className = "plo-trend-delta";
+        deltaEl.textContent = (delta >= 0 ? "+" : "") + delta + "%";
+        wrap.appendChild(deltaEl);
+      }
 
       // Insert before the assessment badge
       const badge = meta.querySelector(".plo-assessment-badge");
@@ -815,7 +837,7 @@
       }
 
       // Click handler for drill-down panel
-      sparkCanvas.addEventListener("click", (e) => {
+      wrap.addEventListener("click", (e) => {
         e.stopPropagation();
         this._toggleTrendPanel(nodeEl, trendPoints, terms, opts);
       });
@@ -853,6 +875,7 @@
       computeYRange,
       getTrendDirection,
       getTrendArrow,
+      getTrendDelta,
     };
   }
 })();

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -1,0 +1,473 @@
+/* global Chart */
+/**
+ * PLO Trend — sparklines + expandable trend charts for the PLO dashboard.
+ *
+ * Fetches multi-term trend data from /api/programs/<id>/plo-dashboard/trend
+ * and injects tiny sparkline canvases into existing PLO/CLO tree nodes,
+ * plus an expandable full chart panel on click.
+ *
+ * Exports `PloTrend` on globalThis for integration tests.
+ */
+
+(function () {
+  "use strict";
+
+  // Chart.js defaults for sparklines
+  const SPARK_WIDTH = 90;
+  const SPARK_HEIGHT = 28;
+  const TREND_LINE_COLOR = "#0d6efd";
+  const TREND_LINE_COLOR_FAIL = "#dc3545";
+  const TREND_FILL_COLOR = "rgba(13, 110, 253, 0.08)";
+  const TREND_NULL_DASH = [4, 4];
+  const THRESHOLD_LINE_COLOR = "rgba(108, 117, 125, 0.3)";
+
+  /**
+   * Determine trend direction from an array of data points.
+   * Returns: "up" | "down" | "flat" | "none"
+   */
+  function getTrendDirection(trendPoints) {
+    // Filter to only non-null points
+    const valid = trendPoints.filter((p) => p !== null && p.pass_rate !== null);
+    if (valid.length < 2) return "none";
+
+    const first = valid[0].pass_rate;
+    const last = valid[valid.length - 1].pass_rate;
+    const diff = last - first;
+
+    if (Math.abs(diff) < 2) return "flat";
+    return diff > 0 ? "up" : "down";
+  }
+
+  /**
+   * Get trend arrow character + CSS class.
+   */
+  function getTrendArrow(direction) {
+    switch (direction) {
+      case "up":
+        return { arrow: "↑", cssClass: "trend-up" };
+      case "down":
+        return { arrow: "↓", cssClass: "trend-down" };
+      case "flat":
+        return { arrow: "→", cssClass: "trend-flat" };
+      default:
+        return { arrow: "", cssClass: "trend-none" };
+    }
+  }
+
+  /**
+   * Create a tiny sparkline canvas element from trend data points.
+   * Returns an HTMLCanvasElement ready to insert into the DOM.
+   */
+  function createSparkline(trendPoints, terms, opts) {
+    const canvas = document.createElement("canvas");
+    canvas.width = SPARK_WIDTH;
+    canvas.height = SPARK_HEIGHT;
+    canvas.className = "plo-sparkline";
+    canvas.style.width = SPARK_WIDTH + "px";
+    canvas.style.height = SPARK_HEIGHT + "px";
+    canvas.title = "Click to view full trend chart";
+
+    if (!trendPoints || trendPoints.length === 0) return canvas;
+
+    // Prepare data: map null points to NaN for Chart.js spanGaps
+    const labels = terms.map((t) => t.term_name || "");
+    const data = trendPoints.map((p) =>
+      p !== null && p.pass_rate !== null ? p.pass_rate : NaN,
+    );
+
+    // Detect which points are from "current" (in-progress) terms
+    const pointStyles = terms.map((t) => (t.is_current ? "rectRot" : "circle"));
+    const pointRadii = terms.map((t) => (t.is_current ? 3 : 2));
+    // Use a segment-based approach for dashed lines at in-progress terms
+    const currentTermIndices = new Set(
+      terms.map((t, i) => (t.is_current ? i : -1)).filter((i) => i >= 0),
+    );
+
+    const threshold = (opts && opts.threshold) || 70;
+
+    // Determine line colour based on latest valid point
+    const lastValid = data.filter((d) => !isNaN(d));
+    const lineColor =
+      lastValid.length > 0 && lastValid[lastValid.length - 1] < threshold
+        ? TREND_LINE_COLOR_FAIL
+        : TREND_LINE_COLOR;
+
+    // Defer rendering until canvas is in the DOM
+    requestAnimationFrame(() => {
+      if (typeof Chart === "undefined") return;
+
+      new Chart(canvas, {
+        type: "line",
+        data: {
+          labels,
+          datasets: [
+            {
+              data,
+              borderColor: lineColor,
+              backgroundColor: TREND_FILL_COLOR,
+              fill: true,
+              tension: 0.3,
+              pointRadius: pointRadii,
+              pointStyle: pointStyles,
+              pointBackgroundColor: lineColor,
+              borderWidth: 1.5,
+              spanGaps: true,
+              segment: {
+                borderDash: (ctx) =>
+                  currentTermIndices.has(ctx.p1DataIndex)
+                    ? TREND_NULL_DASH
+                    : undefined,
+              },
+            },
+          ],
+        },
+        options: {
+          responsive: false,
+          maintainAspectRatio: false,
+          animation: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              enabled: true,
+              callbacks: {
+                title: (items) => items[0]?.label || "",
+                label: (item) =>
+                  item.raw !== null && !isNaN(item.raw)
+                    ? `${Math.round(item.raw)}%`
+                    : "No data",
+              },
+            },
+            annotation: undefined,
+          },
+          scales: {
+            x: { display: false },
+            y: {
+              display: false,
+              min: 0,
+              max: 100,
+              // Threshold reference line via afterDraw plugin
+            },
+          },
+          interaction: {
+            mode: "index",
+            intersect: false,
+          },
+        },
+        plugins: [
+          {
+            id: "thresholdLine",
+            afterDraw(chart) {
+              const yScale = chart.scales.y;
+              if (!yScale) return;
+              const y = yScale.getPixelForValue(threshold);
+              const ctx = chart.ctx;
+              ctx.save();
+              ctx.strokeStyle = THRESHOLD_LINE_COLOR;
+              ctx.lineWidth = 1;
+              ctx.setLineDash([3, 3]);
+              ctx.beginPath();
+              ctx.moveTo(chart.chartArea.left, y);
+              ctx.lineTo(chart.chartArea.right, y);
+              ctx.stroke();
+              ctx.restore();
+            },
+          },
+        ],
+      });
+    });
+
+    return canvas;
+  }
+
+  /**
+   * Create a full-size trend chart panel for drill-down.
+   * Returns a container div with a Chart.js line chart.
+   */
+  function createTrendPanel(trendPoints, terms, opts) {
+    const panel = document.createElement("div");
+    panel.className = "plo-trend-panel";
+
+    const canvas = document.createElement("canvas");
+    canvas.style.width = "100%";
+    canvas.style.height = "200px";
+    panel.appendChild(canvas);
+
+    if (!trendPoints || trendPoints.length === 0) {
+      const msg = document.createElement("p");
+      msg.className = "text-muted text-center py-3";
+      msg.textContent = "No trend data available.";
+      panel.appendChild(msg);
+      return panel;
+    }
+
+    const labels = terms.map((t) => t.term_name || "");
+    const data = trendPoints.map((p) =>
+      p !== null && p.pass_rate !== null ? p.pass_rate : NaN,
+    );
+
+    const threshold = (opts && opts.threshold) || 70;
+    const title = (opts && opts.title) || "Pass Rate Trend";
+
+    const currentTermIndices = new Set(
+      terms.map((t, i) => (t.is_current ? i : -1)).filter((i) => i >= 0),
+    );
+
+    // Determine line colour
+    const lastValid = data.filter((d) => !isNaN(d));
+    const lineColor =
+      lastValid.length > 0 && lastValid[lastValid.length - 1] < threshold
+        ? TREND_LINE_COLOR_FAIL
+        : TREND_LINE_COLOR;
+
+    requestAnimationFrame(() => {
+      if (typeof Chart === "undefined") return;
+
+      new Chart(canvas, {
+        type: "line",
+        data: {
+          labels,
+          datasets: [
+            {
+              label: "Pass Rate %",
+              data,
+              borderColor: lineColor,
+              backgroundColor: TREND_FILL_COLOR,
+              fill: true,
+              tension: 0.3,
+              pointRadius: 4,
+              pointHoverRadius: 6,
+              pointBackgroundColor: lineColor,
+              borderWidth: 2,
+              spanGaps: true,
+              segment: {
+                borderDash: (ctx) =>
+                  currentTermIndices.has(ctx.p1DataIndex)
+                    ? TREND_NULL_DASH
+                    : undefined,
+              },
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          animation: { duration: 300 },
+          plugins: {
+            legend: { display: false },
+            title: {
+              display: true,
+              text: title,
+              font: { size: 13, weight: "normal" },
+              color: "#6c757d",
+            },
+            tooltip: {
+              callbacks: {
+                title: (items) => items[0]?.label || "",
+                label: (item) => {
+                  if (item.raw === null || isNaN(item.raw)) return "No data";
+                  const point = trendPoints[item.dataIndex];
+                  const pct = `${Math.round(item.raw)}%`;
+                  if (point && point.students_took) {
+                    return `${pct} (${point.students_passed}/${point.students_took})`;
+                  }
+                  return pct;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+              ticks: { font: { size: 11 } },
+            },
+            y: {
+              min: 0,
+              max: 100,
+              ticks: {
+                callback: (v) => v + "%",
+                font: { size: 11 },
+              },
+              grid: { color: "rgba(0,0,0,0.05)" },
+            },
+          },
+        },
+        plugins: [
+          {
+            id: "thresholdLine",
+            afterDraw(chart) {
+              const yScale = chart.scales.y;
+              if (!yScale) return;
+              const y = yScale.getPixelForValue(threshold);
+              const ctx = chart.ctx;
+              ctx.save();
+              ctx.strokeStyle = "rgba(220, 53, 69, 0.4)";
+              ctx.lineWidth = 1;
+              ctx.setLineDash([6, 4]);
+              ctx.beginPath();
+              ctx.moveTo(chart.chartArea.left, y);
+              ctx.lineTo(chart.chartArea.right, y);
+              ctx.stroke();
+              // Label
+              ctx.fillStyle = "rgba(220, 53, 69, 0.6)";
+              ctx.font = "10px sans-serif";
+              ctx.fillText(
+                `Threshold ${threshold}%`,
+                chart.chartArea.right - 80,
+                y - 4,
+              );
+              ctx.restore();
+            },
+          },
+        ],
+      });
+    });
+
+    return panel;
+  }
+
+  // -----------------------------------------------------------------------
+  // PloTrend controller — fetches data and wires into the existing tree
+  // -----------------------------------------------------------------------
+  const PloTrend = {
+    trendData: null,
+
+    /**
+     * Fetch trend data for the given program and inject sparklines
+     * into the already-rendered PLO tree.
+     */
+    async loadTrend(programId) {
+      if (!programId) return;
+
+      const url = `/api/programs/${encodeURIComponent(programId)}/plo-dashboard/trend`;
+      try {
+        const resp = await fetch(url, {
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (!data.success) return;
+        this.trendData = data;
+        this.injectSparklines();
+      } catch (err) {
+        console.warn("PloTrend: failed to load trend data", err);
+      }
+    },
+
+    /**
+     * Walk the DOM tree and inject sparklines next to assessment badges.
+     */
+    injectSparklines() {
+      if (!this.trendData) return;
+      const { terms, plos } = this.trendData;
+      if (!terms || terms.length < 2) return; // need ≥2 terms for a trend
+
+      const container = document.getElementById("ploTreeContainer");
+      if (!container) return;
+
+      // Remove any previously injected sparklines
+      container
+        .querySelectorAll(".plo-sparkline-wrap, .plo-trend-panel")
+        .forEach((el) => el.remove());
+
+      (plos || []).forEach((plo) => {
+        // Find the PLO node in the DOM
+        const ploNode = container.querySelector(`[data-plo-id="${plo.id}"]`);
+        if (ploNode) {
+          this._injectIntoNode(ploNode, plo.trend, terms, {
+            title: `PLO-${plo.plo_number}: ${plo.description}`,
+          });
+        }
+
+        // CLO nodes
+        (plo.clos || []).forEach((clo) => {
+          const cloNode = container.querySelector(
+            `[data-clo-id="${clo.outcome_id}"]`,
+          );
+          if (cloNode) {
+            this._injectIntoNode(cloNode, clo.trend, terms, {
+              title: `${clo.course_number || ""} CLO ${clo.clo_number || "?"}: ${clo.description || ""}`,
+            });
+          }
+        });
+      });
+    },
+
+    /**
+     * Inject a sparkline + trend arrow into a tree node's meta area,
+     * and wire a click handler to toggle a full trend chart panel.
+     */
+    _injectIntoNode(nodeEl, trendPoints, terms, opts) {
+      if (!trendPoints || trendPoints.length < 2) return;
+
+      const header = nodeEl.querySelector(".plo-tree-header");
+      if (!header) return;
+      const meta = header.querySelector(".plo-tree-meta");
+      if (!meta) return;
+
+      // Trend direction arrow
+      const direction = getTrendDirection(trendPoints);
+      const { arrow, cssClass } = getTrendArrow(direction);
+
+      // Wrap sparkline + arrow
+      const wrap = document.createElement("span");
+      wrap.className = "plo-sparkline-wrap";
+
+      if (arrow) {
+        const arrowEl = document.createElement("span");
+        arrowEl.className = `plo-trend-arrow ${cssClass}`;
+        arrowEl.textContent = arrow;
+        wrap.appendChild(arrowEl);
+      }
+
+      const sparkCanvas = createSparkline(trendPoints, terms, opts);
+      wrap.appendChild(sparkCanvas);
+
+      // Insert before the assessment badge
+      const badge = meta.querySelector(".plo-assessment-badge");
+      if (badge) {
+        meta.insertBefore(wrap, badge);
+      } else {
+        meta.insertBefore(wrap, meta.firstChild);
+      }
+
+      // Click handler for drill-down panel
+      sparkCanvas.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this._toggleTrendPanel(nodeEl, trendPoints, terms, opts);
+      });
+    },
+
+    _toggleTrendPanel(nodeEl, trendPoints, terms, opts) {
+      // Check if panel already exists
+      const existing = nodeEl.querySelector(".plo-trend-panel");
+      if (existing) {
+        existing.remove();
+        return;
+      }
+
+      const panel = createTrendPanel(trendPoints, terms, opts);
+      // Insert after the header, before children
+      const header = nodeEl.querySelector(".plo-tree-header");
+      if (header && header.nextSibling) {
+        nodeEl.insertBefore(panel, header.nextSibling);
+      } else {
+        nodeEl.appendChild(panel);
+      }
+    },
+  };
+
+  // Exports
+  if (typeof globalThis !== "undefined") {
+    globalThis.PloTrend = PloTrend;
+  }
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      PloTrend,
+      createSparkline,
+      createTrendPanel,
+      getTrendDirection,
+      getTrendArrow,
+    };
+  }
+})();

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -193,9 +193,106 @@
     return canvas;
   }
 
+  // Palette for CLO overlay lines (visually distinct, semi-transparent)
+  const CLO_COLORS = [
+    "rgba(255, 99, 132, 0.55)",
+    "rgba(54, 162, 235, 0.55)",
+    "rgba(255, 206, 86, 0.65)",
+    "rgba(75, 192, 192, 0.55)",
+    "rgba(153, 102, 255, 0.55)",
+    "rgba(255, 159, 64, 0.55)",
+    "rgba(199, 199, 199, 0.6)",
+    "rgba(83, 102, 55, 0.55)",
+    "rgba(201, 76, 76, 0.55)",
+    "rgba(107, 91, 149, 0.55)",
+  ];
+
+  /**
+   * Build a short label for a CLO suitable for chart legends.
+   */
+  function cloLabel(clo) {
+    const course = clo.course_number || "";
+    const num = clo.clo_number || "?";
+    return `${course} CLO ${num}`;
+  }
+
+  /**
+   * Create a CLO composition bar element showing which courses
+   * contributed data in each term.
+   * Returns a div containing colored pills per term.
+   */
+  function createCompositionBar(clos, terms) {
+    const bar = document.createElement("div");
+    bar.className = "plo-composition-bar";
+
+    // Collect unique courses and assign colours
+    const courseSet = new Map();
+    (clos || []).forEach((clo) => {
+      const cn = clo.course_number || "?";
+      if (!courseSet.has(cn)) {
+        courseSet.set(cn, CLO_COLORS[courseSet.size % CLO_COLORS.length]);
+      }
+    });
+
+    // One cell per term
+    terms.forEach((tm, ti) => {
+      const cell = document.createElement("div");
+      cell.className = "plo-comp-cell";
+
+      // Which courses have data in this term?
+      const activeCourses = new Set();
+      (clos || []).forEach((clo) => {
+        const pt = (clo.trend || [])[ti];
+        if (pt && pt.pass_rate !== null) {
+          activeCourses.add(clo.course_number || "?");
+        }
+      });
+
+      if (activeCourses.size === 0) {
+        const dot = document.createElement("span");
+        dot.className = "plo-comp-dot plo-comp-empty";
+        dot.title = `${tm.term_name}: no data`;
+        cell.appendChild(dot);
+      } else {
+        activeCourses.forEach((cn) => {
+          const dot = document.createElement("span");
+          dot.className = "plo-comp-dot";
+          dot.style.backgroundColor = courseSet.get(cn) || "#ccc";
+          dot.title = `${tm.term_name}: ${cn}`;
+          cell.appendChild(dot);
+        });
+      }
+      bar.appendChild(cell);
+    });
+
+    // Legend
+    if (courseSet.size > 0) {
+      const legend = document.createElement("div");
+      legend.className = "plo-comp-legend";
+      courseSet.forEach((color, cn) => {
+        const item = document.createElement("span");
+        item.className = "plo-comp-legend-item";
+        const swatch = document.createElement("span");
+        swatch.className = "plo-comp-swatch";
+        swatch.style.backgroundColor = color;
+        item.appendChild(swatch);
+        item.appendChild(document.createTextNode(cn));
+        legend.appendChild(item);
+      });
+      bar.appendChild(legend);
+    }
+
+    return bar;
+  }
+
   /**
    * Create a full-size trend chart panel for drill-down.
    * Returns a container div with a Chart.js line chart.
+   *
+   * When opts.clos is provided (PLO-level chart), renders:
+   * - Semi-transparent CLO overlay lines
+   * - Enriched tooltip showing per-CLO breakdown
+   * When opts.discontinuities is provided, renders vertical annotations.
    */
   function createTrendPanel(trendPoints, terms, opts) {
     const panel = document.createElement("div");
@@ -233,6 +330,8 @@
 
     const threshold = (opts && opts.threshold) || 70;
     const title = (opts && opts.title) || "Pass Rate Trend";
+    const clos = (opts && opts.clos) || [];
+    const discontinuities = (opts && opts.discontinuities) || [];
 
     const currentTermIndices = new Set(
       terms.map((t, i) => (t.is_current ? i : -1)).filter((i) => i >= 0),
@@ -255,43 +354,80 @@
         ? TREND_LINE_COLOR_FAIL
         : TREND_LINE_COLOR;
 
+    // --- Build datasets array ---
+    const datasets = [
+      {
+        label: "PLO Pass Rate %",
+        data,
+        borderColor: lineColor,
+        backgroundColor: TREND_FILL_COLOR,
+        fill: true,
+        tension: 0.3,
+        pointRadius: failRadii,
+        pointHoverRadius: 6,
+        pointBackgroundColor: pointColors,
+        pointBorderColor: pointBorders,
+        pointBorderWidth: 1.5,
+        borderWidth: 2.5,
+        spanGaps: true,
+        order: 0, // draw on top
+        segment: {
+          borderDash: (ctx) =>
+            currentTermIndices.has(ctx.p1DataIndex)
+              ? TREND_NULL_DASH
+              : undefined,
+        },
+      },
+    ];
+
+    // --- CLO overlay lines (Feature #1) ---
+    if (clos.length > 0) {
+      clos.forEach((clo, ci) => {
+        const color = CLO_COLORS[ci % CLO_COLORS.length];
+        const cloData = (clo.trend || []).map((p) =>
+          p !== null && p.pass_rate !== null ? p.pass_rate : NaN,
+        );
+        datasets.push({
+          label: cloLabel(clo),
+          data: cloData,
+          borderColor: color,
+          backgroundColor: "transparent",
+          fill: false,
+          tension: 0.3,
+          pointRadius: 2,
+          pointHoverRadius: 4,
+          pointBackgroundColor: color,
+          pointBorderColor: color,
+          borderWidth: 1.5,
+          borderDash: [4, 3],
+          spanGaps: true,
+          order: 1, // behind PLO line
+        });
+      });
+    }
+
     requestAnimationFrame(() => {
       if (typeof Chart === "undefined") return;
 
       new Chart(canvas, {
         type: "line",
-        data: {
-          labels,
-          datasets: [
-            {
-              label: "Pass Rate %",
-              data,
-              borderColor: lineColor,
-              backgroundColor: TREND_FILL_COLOR,
-              fill: true,
-              tension: 0.3,
-              pointRadius: failRadii,
-              pointHoverRadius: 6,
-              pointBackgroundColor: pointColors,
-              pointBorderColor: pointBorders,
-              pointBorderWidth: 1.5,
-              borderWidth: 2,
-              spanGaps: true,
-              segment: {
-                borderDash: (ctx) =>
-                  currentTermIndices.has(ctx.p1DataIndex)
-                    ? TREND_NULL_DASH
-                    : undefined,
-              },
-            },
-          ],
-        },
+        data: { labels, datasets },
         options: {
           responsive: true,
           maintainAspectRatio: false,
           animation: { duration: 300 },
           plugins: {
-            legend: { display: false },
+            legend: {
+              display: clos.length > 0,
+              position: "bottom",
+              labels: {
+                usePointStyle: true,
+                pointStyle: "line",
+                font: { size: 10 },
+                boxWidth: 20,
+                padding: 8,
+              },
+            },
             title: {
               display: true,
               text: title,
@@ -299,17 +435,33 @@
               color: "#6c757d",
             },
             tooltip: {
+              mode: "index",
+              intersect: false,
               callbacks: {
                 title: (items) => items[0]?.label || "",
                 label: (item) => {
-                  if (item.raw === null || isNaN(item.raw)) return "No data";
-                  const point = trendPoints[item.dataIndex];
+                  if (item.raw === null || isNaN(item.raw)) return null;
+                  const dsIndex = item.datasetIndex;
                   const pct = `${Math.round(item.raw)}%`;
-                  if (point && point.students_took) {
-                    return `${pct} (${point.students_passed}/${point.students_took})`;
+                  if (dsIndex === 0) {
+                    // PLO aggregate line
+                    const point = trendPoints[item.dataIndex];
+                    if (point && point.students_took) {
+                      return `PLO: ${pct} (${point.students_passed}/${point.students_took})`;
+                    }
+                    return `PLO: ${pct}`;
                   }
-                  return pct;
+                  // CLO overlay line
+                  const cloIdx = dsIndex - 1;
+                  const clo = clos[cloIdx];
+                  const cloPoint = clo && (clo.trend || [])[item.dataIndex];
+                  if (cloPoint && cloPoint.students_took) {
+                    return `${item.dataset.label}: ${pct} (${cloPoint.students_passed}/${cloPoint.students_took})`;
+                  }
+                  return `${item.dataset.label}: ${pct}`;
                 },
+                // Filter out null entries from tooltip
+                filter: (item) => item.raw !== null && !isNaN(item.raw),
               },
             },
           },
@@ -327,6 +479,19 @@
               },
               grid: { color: "rgba(0,0,0,0.05)" },
             },
+          },
+          // Click-to-drill: clicking a data point sets the term filter
+          onClick(_event, elements) {
+            if (!elements || elements.length === 0) return;
+            const idx = elements[0].index;
+            const term = terms[idx];
+            if (!term) return;
+
+            const termFilter = document.getElementById("ploTermFilter");
+            if (termFilter) {
+              termFilter.value = term.term_id;
+              termFilter.dispatchEvent(new Event("change"));
+            }
           },
         },
         plugins: [
@@ -356,9 +521,62 @@
               ctx.restore();
             },
           },
+          {
+            id: "discontinuityLines",
+            afterDraw(chart) {
+              if (!discontinuities || discontinuities.length === 0) return;
+              const xScale = chart.scales.x;
+              const yScale = chart.scales.y;
+              if (!xScale || !yScale) return;
+              const ctx = chart.ctx;
+
+              discontinuities.forEach((d) => {
+                const ti = d.term_index;
+                if (ti < 0 || ti >= labels.length) return;
+
+                // Draw between previous and current term
+                const xCurr = xScale.getPixelForValue(ti);
+                const xPrev = ti > 0 ? xScale.getPixelForValue(ti - 1) : xCurr;
+                const x = (xPrev + xCurr) / 2;
+
+                ctx.save();
+                ctx.strokeStyle = "rgba(255, 152, 0, 0.6)";
+                ctx.lineWidth = 1.5;
+                ctx.setLineDash([4, 3]);
+                ctx.beginPath();
+                ctx.moveTo(x, chart.chartArea.top);
+                ctx.lineTo(x, chart.chartArea.bottom);
+                ctx.stroke();
+
+                // Label
+                ctx.fillStyle = "rgba(255, 152, 0, 0.85)";
+                ctx.font = "9px sans-serif";
+                ctx.textAlign = "center";
+
+                // Build summary text
+                const parts = [];
+                if (d.added && d.added.length > 0) {
+                  parts.push("+" + d.added.map((a) => a.label).join(", +"));
+                }
+                if (d.removed && d.removed.length > 0) {
+                  parts.push("−" + d.removed.map((r) => r.label).join(", −"));
+                }
+                const summary = parts.join("  ") || "CLO change";
+                ctx.fillText(summary, x, chart.chartArea.top - 4);
+
+                ctx.restore();
+              });
+            },
+          },
         ],
       });
     });
+
+    // --- CLO Composition bar (Feature #4) ---
+    if (clos.length > 0) {
+      const compBar = createCompositionBar(clos, terms);
+      panel.appendChild(compBar);
+    }
 
     return panel;
   }
@@ -414,6 +632,8 @@
         if (ploNode) {
           this._injectIntoNode(ploNode, plo.trend, terms, {
             title: `PLO-${plo.plo_number}: ${plo.description}`,
+            clos: plo.clos || [],
+            discontinuities: plo.discontinuities || [],
           });
         }
 
@@ -504,6 +724,7 @@
       PloTrend,
       createSparkline,
       createTrendPanel,
+      createCompositionBar,
       getTrendDirection,
       getTrendArrow,
     };

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -929,10 +929,17 @@
         });
         slot.insertBefore(canvas, slot.firstChild);
 
+        // When a historical term is selected, compute badge from data up to
+        // that term only so the arrow + delta match the visible sparkline.
+        const badgeTrend =
+          selectedTermIndex != null && selectedTermIndex >= 0
+            ? plo.trend.slice(0, selectedTermIndex + 1)
+            : plo.trend;
+
         // Add compact trend badge (arrow + delta) after the sparkline
-        const direction = getTrendDirection(plo.trend);
+        const direction = getTrendDirection(badgeTrend);
         const { arrow, cssClass } = getTrendArrow(direction);
-        const delta = getTrendDelta(plo.trend);
+        const delta = getTrendDelta(badgeTrend);
         if (arrow) {
           const badge = document.createElement("span");
           badge.className = "plo-trend-indicator plo-trend-indicator--mini";
@@ -1012,10 +1019,13 @@
       const meta = header.querySelector(".plo-tree-meta");
       if (!meta) return;
 
-      // Trend direction + delta
-      const direction = getTrendDirection(trendPoints);
+      // Trend direction + delta – scope to selected term when applicable
+      const idx = opts && opts.selectedTermIndex;
+      const badgeTrend =
+        idx != null && idx >= 0 ? trendPoints.slice(0, idx + 1) : trendPoints;
+      const direction = getTrendDirection(badgeTrend);
       const { arrow, cssClass } = getTrendArrow(direction);
-      const delta = getTrendDelta(trendPoints);
+      const delta = getTrendDelta(badgeTrend);
 
       // Build compact trend indicator
       const wrap = document.createElement("span");

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -519,6 +519,18 @@
                   }
                   return `${item.dataset.label}: ${pct}`;
                 },
+                afterLabel: (item) => {
+                  if (item.raw === null || isNaN(item.raw)) return "";
+                  const dsIndex = item.datasetIndex;
+                  if (dsIndex === 0) return ""; // PLO line — no description
+                  const clo = clos[dsIndex - 1];
+                  if (clo && clo.description) {
+                    const desc = clo.description;
+                    // Truncate long descriptions for tooltip readability
+                    return `  "${desc.length > 60 ? desc.slice(0, 57) + "…" : desc}"`;
+                  }
+                  return "";
+                },
                 // Filter out null entries from tooltip
                 filter: (item) => item.raw !== null && !isNaN(item.raw),
                 afterBody: (items) => {

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -207,6 +207,35 @@
     "rgba(107, 91, 149, 0.55)",
   ];
 
+  // Stable palette for composition-bar course swatches.
+  // Each course gets the same colour as its CLO overlay line on the chart.
+  const COMP_COLORS = CLO_COLORS;
+
+  /**
+   * Compute a nice Y-axis range that zooms into the data.
+   * Returns { min, max } with ~10% padding above and below,
+   * clamped to [0, 100].
+   */
+  function computeYRange(datasets) {
+    let lo = Infinity;
+    let hi = -Infinity;
+    datasets.forEach((ds) => {
+      (ds.data || []).forEach((v) => {
+        if (v !== null && !isNaN(v)) {
+          if (v < lo) lo = v;
+          if (v > hi) hi = v;
+        }
+      });
+    });
+    if (!isFinite(lo) || !isFinite(hi)) return { min: 0, max: 100 };
+    const span = hi - lo || 10; // avoid zero span
+    const pad = span * 0.15;
+    return {
+      min: Math.max(0, Math.floor((lo - pad) / 5) * 5),
+      max: Math.min(100, Math.ceil((hi + pad) / 5) * 5),
+    };
+  }
+
   /**
    * Build a short label for a CLO suitable for chart legends.
    */
@@ -225,12 +254,12 @@
     const bar = document.createElement("div");
     bar.className = "plo-composition-bar";
 
-    // Collect unique courses and assign colours
+    // Collect unique courses and assign colours (same palette as chart lines)
     const courseSet = new Map();
-    (clos || []).forEach((clo) => {
+    (clos || []).forEach((clo, ci) => {
       const cn = clo.course_number || "?";
       if (!courseSet.has(cn)) {
-        courseSet.set(cn, CLO_COLORS[courseSet.size % CLO_COLORS.length]);
+        courseSet.set(cn, COMP_COLORS[ci % COMP_COLORS.length]);
       }
     });
 
@@ -298,28 +327,40 @@
     const panel = document.createElement("div");
     panel.className = "plo-trend-panel";
 
-    // Close button
-    const closeBtn = document.createElement("button");
-    closeBtn.type = "button";
-    closeBtn.className = "plo-trend-panel-close";
-    closeBtn.innerHTML = "&times;";
-    closeBtn.title = "Close trend chart";
-    closeBtn.addEventListener("click", (e) => {
+    // Visibility toggle button (eyeball icon)
+    const toggleBtn = document.createElement("button");
+    toggleBtn.type = "button";
+    toggleBtn.className = "plo-trend-panel-toggle";
+    toggleBtn.innerHTML = "&#128065;"; // 👁 open eye
+    toggleBtn.title = "Hide trend chart";
+    toggleBtn.setAttribute("aria-label", "Toggle trend chart visibility");
+    toggleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      panel.remove();
+      const body = panel.querySelector(".plo-trend-panel-body");
+      if (!body) return;
+      const hidden = body.style.display === "none";
+      body.style.display = hidden ? "" : "none";
+      toggleBtn.innerHTML = hidden ? "&#128065;" : "&#128064;"; // 👁 vs 👀
+      toggleBtn.title = hidden ? "Hide trend chart" : "Show trend chart";
+      panel.classList.toggle("plo-trend-panel--collapsed", !hidden);
     });
-    panel.appendChild(closeBtn);
+    panel.appendChild(toggleBtn);
+
+    // Wrap canvas + composition bar in a body div for show/hide
+    const body = document.createElement("div");
+    body.className = "plo-trend-panel-body";
 
     const canvas = document.createElement("canvas");
     canvas.style.width = "100%";
-    canvas.style.height = "200px";
-    panel.appendChild(canvas);
+    canvas.style.height = "300px";
+    body.appendChild(canvas);
+    panel.appendChild(body);
 
     if (!trendPoints || trendPoints.length === 0) {
       const msg = document.createElement("p");
       msg.className = "text-muted text-center py-3";
       msg.textContent = "No trend data available.";
-      panel.appendChild(msg);
+      body.appendChild(msg);
       return panel;
     }
 
@@ -427,6 +468,25 @@
                 boxWidth: 20,
                 padding: 8,
               },
+              onClick(_e, legendItem, legend) {
+                const chart = legend.chart;
+                const ci = legendItem.datasetIndex;
+                const allHidden = chart.data.datasets.every(
+                  (ds, i) => i === ci || !chart.isDatasetVisible(i),
+                );
+                if (allHidden) {
+                  // Un-solo: show all
+                  chart.data.datasets.forEach((_ds, i) => {
+                    chart.setDatasetVisibility(i, true);
+                  });
+                } else {
+                  // Solo: show only clicked
+                  chart.data.datasets.forEach((_ds, i) => {
+                    chart.setDatasetVisibility(i, i === ci);
+                  });
+                }
+                chart.update();
+              },
             },
             title: {
               display: true,
@@ -462,6 +522,39 @@
                 },
                 // Filter out null entries from tooltip
                 filter: (item) => item.raw !== null && !isNaN(item.raw),
+                afterBody: (items) => {
+                  if (!discontinuities || discontinuities.length === 0)
+                    return "";
+                  const idx = items[0] && items[0].dataIndex;
+                  if (idx == null) return "";
+                  // Find any discontinuity AT this term index
+                  const disc = discontinuities.find(
+                    (d) => d.term_index === idx,
+                  );
+                  if (!disc) return "";
+                  const lines = ["\n─── Course changes ───"];
+                  const prev = [];
+                  const curr = [];
+                  if (disc.removed && disc.removed.length > 0) {
+                    disc.removed.forEach((r) => prev.push(r.label));
+                  }
+                  if (disc.added && disc.added.length > 0) {
+                    disc.added.forEach((a) => curr.push(a.label));
+                  }
+                  if (prev.length > 0 || curr.length > 0) {
+                    const maxLen = Math.max(prev.length, curr.length);
+                    for (let i = 0; i < maxLen; i++) {
+                      const left = prev[i] ? "− " + prev[i] : "";
+                      const right = curr[i] ? "+ " + curr[i] : "";
+                      if (left && right) {
+                        lines.push(left + "  │  " + right);
+                      } else {
+                        lines.push(left || "          │  " + right);
+                      }
+                    }
+                  }
+                  return lines;
+                },
               },
             },
           },
@@ -471,8 +564,7 @@
               ticks: { font: { size: 11 } },
             },
             y: {
-              min: 0,
-              max: 100,
+              ...computeYRange(datasets),
               ticks: {
                 callback: (v) => v + "%",
                 font: { size: 11 },
@@ -534,37 +626,21 @@
                 const ti = d.term_index;
                 if (ti < 0 || ti >= labels.length) return;
 
-                // Draw between previous and current term
+                // Subtle hairline between previous and current term
                 const xCurr = xScale.getPixelForValue(ti);
                 const xPrev = ti > 0 ? xScale.getPixelForValue(ti - 1) : xCurr;
                 const x = (xPrev + xCurr) / 2;
 
                 ctx.save();
-                ctx.strokeStyle = "rgba(255, 152, 0, 0.6)";
-                ctx.lineWidth = 1.5;
-                ctx.setLineDash([4, 3]);
+                ctx.strokeStyle = "rgba(255, 152, 0, 0.2)";
+                ctx.lineWidth = 1;
+                ctx.setLineDash([]);
                 ctx.beginPath();
                 ctx.moveTo(x, chart.chartArea.top);
                 ctx.lineTo(x, chart.chartArea.bottom);
                 ctx.stroke();
-
-                // Label
-                ctx.fillStyle = "rgba(255, 152, 0, 0.85)";
-                ctx.font = "9px sans-serif";
-                ctx.textAlign = "center";
-
-                // Build summary text
-                const parts = [];
-                if (d.added && d.added.length > 0) {
-                  parts.push("+" + d.added.map((a) => a.label).join(", +"));
-                }
-                if (d.removed && d.removed.length > 0) {
-                  parts.push("−" + d.removed.map((r) => r.label).join(", −"));
-                }
-                const summary = parts.join("  ") || "CLO change";
-                ctx.fillText(summary, x, chart.chartArea.top - 4);
-
                 ctx.restore();
+                // Text labels removed — details shown in tooltip afterBody
               });
             },
           },
@@ -575,7 +651,7 @@
     // --- CLO Composition bar (Feature #4) ---
     if (clos.length > 0) {
       const compBar = createCompositionBar(clos, terms);
-      panel.appendChild(compBar);
+      body.appendChild(compBar);
     }
 
     return panel;
@@ -725,6 +801,7 @@
       createSparkline,
       createTrendPanel,
       createCompositionBar,
+      computeYRange,
       getTrendDirection,
       getTrendArrow,
     };

--- a/static/plo_trend.js
+++ b/static/plo_trend.js
@@ -186,6 +186,32 @@
               ctx.restore();
             },
           },
+          {
+            id: "sparkDiscontinuity",
+            afterDraw(chart) {
+              const discs = (opts && opts.discontinuities) || [];
+              if (discs.length === 0) return;
+              const xScale = chart.scales.x;
+              if (!xScale) return;
+              const ctx = chart.ctx;
+              discs.forEach((d) => {
+                const ti = d.term_index;
+                if (ti < 0 || ti >= labels.length) return;
+                const xCurr = xScale.getPixelForValue(ti);
+                const xPrev = ti > 0 ? xScale.getPixelForValue(ti - 1) : xCurr;
+                const x = (xPrev + xCurr) / 2;
+                ctx.save();
+                ctx.strokeStyle = "rgba(255, 152, 0, 0.35)";
+                ctx.lineWidth = 1;
+                ctx.setLineDash([]);
+                ctx.beginPath();
+                ctx.moveTo(x, chart.chartArea.top);
+                ctx.lineTo(x, chart.chartArea.bottom);
+                ctx.stroke();
+                ctx.restore();
+              });
+            },
+          },
         ],
       });
     });
@@ -396,9 +422,13 @@
         : TREND_LINE_COLOR;
 
     // --- Build datasets array ---
+    // For CLO-level charts (no CLO overlays), use a context-aware label
+    const mainLabel =
+      (opts && opts.mainLabel) || (clos.length > 0 ? "PLO Pass Rate %" : title);
+
     const datasets = [
       {
-        label: "PLO Pass Rate %",
+        label: mainLabel,
         data,
         borderColor: lineColor,
         backgroundColor: TREND_FILL_COLOR,
@@ -503,12 +533,12 @@
                   const dsIndex = item.datasetIndex;
                   const pct = `${Math.round(item.raw)}%`;
                   if (dsIndex === 0) {
-                    // PLO aggregate line
+                    // Main line (PLO aggregate or CLO individual)
                     const point = trendPoints[item.dataIndex];
                     if (point && point.students_took) {
-                      return `PLO: ${pct} (${point.students_passed}/${point.students_took})`;
+                      return `${item.dataset.label}: ${pct} (${point.students_passed}/${point.students_took})`;
                     }
-                    return `PLO: ${pct}`;
+                    return `${item.dataset.label}: ${pct}`;
                   }
                   // CLO overlay line
                   const cloIdx = dsIndex - 1;
@@ -739,6 +769,7 @@
               .forEach((el) => el.remove());
             this._injectIntoNode(cloNode, clo.trend, terms, {
               title: `${clo.course_number || ""} CLO ${clo.clo_number || "?"}: ${clo.description || ""}`,
+              discontinuities: plo.discontinuities || [],
             });
           }
         });

--- a/static/program_dashboard.js
+++ b/static/program_dashboard.js
@@ -467,7 +467,7 @@
           return this._summarisePloTree(prog, body);
         } catch (err) {
           // eslint-disable-next-line no-console
-          console.warn(`PLO summary fetch failed for ${pid}:`, err);
+          console.warn("PLO summary fetch failed for " + pid + ":", err); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
           return {
             program: prog.program_name || pid,
             plo_count: "—",

--- a/templates/plo_dashboard.html
+++ b/templates/plo_dashboard.html
@@ -19,7 +19,7 @@
             </p>
         </div>
         <div>
-            <button class="btn btn-primary" id="createPloBtn">
+            <button class="btn btn-primary" id="createPloBtn" style="display:none">
                 <i class="fas fa-plus me-1"></i> New PLO
             </button>
         </div>

--- a/templates/plo_dashboard.html
+++ b/templates/plo_dashboard.html
@@ -206,6 +206,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="{{ url_for('static', filename='dashboard_utils.js') }}"></script>
+<script src="{{ url_for('static', filename='plo_trend.js') }}"></script>
 <script src="{{ url_for('static', filename='plo_dashboard.js') }}"></script>
 {% endblock %}

--- a/templates/plo_dashboard.html
+++ b/templates/plo_dashboard.html
@@ -25,42 +25,6 @@
         </div>
     </div>
 
-    <!-- Summary stats -->
-    <div class="row mb-4">
-        <div class="col">
-            <div class="card" style="border-color: #0d6efd; border-width: 2px;">
-                <div class="card-body text-center py-2">
-                    <h4 class="mb-0" id="statPloCount" style="color: #0d6efd;">-</h4>
-                    <p class="mb-0 small" style="color: #0d6efd;">Program Outcomes</p>
-                </div>
-            </div>
-        </div>
-        <div class="col">
-            <div class="card" style="border-color: #6c757d; border-width: 2px;">
-                <div class="card-body text-center py-2">
-                    <h4 class="mb-0" id="statMappedCloCount" style="color: #6c757d;">-</h4>
-                    <p class="mb-0 small" style="color: #6c757d;">Mapped CLOs</p>
-                </div>
-            </div>
-        </div>
-        <div class="col">
-            <div class="card" style="border-color: #198754; border-width: 2px;">
-                <div class="card-body text-center py-2">
-                    <h4 class="mb-0" id="statOverallPassRate" style="color: #198754;">-</h4>
-                    <p class="mb-0 small" style="color: #198754;">Overall Pass Rate</p>
-                </div>
-            </div>
-        </div>
-        <div class="col">
-            <div class="card" style="border-color: #fd7e14; border-width: 2px;">
-                <div class="card-body text-center py-2">
-                    <h4 class="mb-0" id="statMappingStatus" style="color: #fd7e14;">-</h4>
-                    <p class="mb-0 small" style="color: #fd7e14;">Mapping Status</p>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- Filters -->
     <div class="card mb-4">
         <div class="card-body py-3">

--- a/templates/plo_dashboard.html
+++ b/templates/plo_dashboard.html
@@ -100,12 +100,12 @@
             <form id="ploForm">
                 <div class="modal-body">
                     <input type="hidden" id="ploModalId">
-                    <div class="mb-3">
-                        <label for="ploModalNumber" class="form-label">PLO Number *</label>
+                    <div class="mb-3 d-none" id="ploModalNumberGroup">
+                        <label for="ploModalNumber" class="form-label">PLO Number</label>
                         <input type="number" min="1" class="form-control" id="ploModalNumber"
-                               required placeholder="e.g. 5">
+                               readonly>
                         <small class="text-muted">
-                            Displayed as PLO-&lt;n&gt;. Must be unique within this program.
+                            Automatically assigned. Displayed as PLO-&lt;n&gt;.
                         </small>
                     </div>
                     <div class="mb-3">

--- a/templates/plo_dashboard.html
+++ b/templates/plo_dashboard.html
@@ -170,7 +170,9 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+        integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" {# pragma: allowlist secret - SRI hash #}
+        crossorigin="anonymous"></script>
 <script src="{{ url_for('static', filename='dashboard_utils.js') }}"></script>
 <script src="{{ url_for('static', filename='plo_trend.js') }}"></script>
 <script src="{{ url_for('static', filename='plo_dashboard.js') }}"></script>

--- a/tests/javascript/unit/plo_dashboard.test.js
+++ b/tests/javascript/unit/plo_dashboard.test.js
@@ -1172,3 +1172,90 @@ describe('PloDashboard — small helpers', () => {
     expect(m.style.display).toBe('none');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Summary bar
+// ---------------------------------------------------------------------------
+describe('PloDashboard — _buildSummaryBar', () => {
+  test('renders stats and progress bar for mixed PLO statuses', () => {
+    const plos = [
+      { aggregate: { pass_rate: 90 } },
+      { aggregate: { pass_rate: 85 } },
+      { aggregate: { pass_rate: 60 } },
+      { aggregate: { pass_rate: null } },
+    ];
+
+    const bar = PloDashboard._buildSummaryBar(plos);
+    expect(bar.className).toBe('plo-summary-bar');
+
+    // Stats: 2 satisfactory, 1 needs attention, 1 no data
+    const stats = bar.querySelectorAll('.plo-summary-stat');
+    expect(stats.length).toBe(3);
+    expect(stats[0].textContent).toContain('2');
+    expect(stats[0].textContent).toContain('satisfactory');
+    expect(stats[1].textContent).toContain('1');
+    expect(stats[1].textContent).toContain('needs attention');
+    expect(stats[2].textContent).toContain('1');
+    expect(stats[2].textContent).toContain('no data');
+
+    // Progress bar has 3 segments
+    const segments = bar.querySelectorAll('.plo-summary-segment');
+    expect(segments.length).toBe(3);
+    expect(segments[0].className).toContain('seg-pass');
+    expect(segments[1].className).toContain('seg-fail');
+    expect(segments[2].className).toContain('seg-nodata');
+  });
+
+  test('omits zero-count categories', () => {
+    const plos = [
+      { aggregate: { pass_rate: 90 } },
+      { aggregate: { pass_rate: 80 } },
+    ];
+
+    const bar = PloDashboard._buildSummaryBar(plos);
+    const stats = bar.querySelectorAll('.plo-summary-stat');
+    expect(stats.length).toBe(1);
+    expect(stats[0].textContent).toContain('satisfactory');
+    const segments = bar.querySelectorAll('.plo-summary-segment');
+    expect(segments.length).toBe(1);
+  });
+
+  test('returns empty bar for null/empty plos', () => {
+    const bar = PloDashboard._buildSummaryBar([]);
+    expect(bar.querySelector('.plo-summary-stat')).toBeNull();
+
+    const bar2 = PloDashboard._buildSummaryBar(null);
+    expect(bar2.querySelector('.plo-summary-stat')).toBeNull();
+  });
+
+  test('summary bar is inserted above tree in renderTree', async () => {
+    setBody(SKELETON);
+    resetDashboardState();
+    PloDashboard._cacheSelectors();
+    PloDashboard.programs = [{ program_id: 'prog-1', name: 'Biology BS' }];
+    PloDashboard.currentProgramId = 'prog-1';
+    PloDashboard.currentTermId = 't-active';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_TREE,
+    });
+    await PloDashboard.loadTree();
+    delete global.fetch;
+
+    const container = document.getElementById('ploTreeContainer');
+    const summaryBar = container.querySelector('.plo-summary-bar');
+    expect(summaryBar).not.toBeNull();
+
+    // SAMPLE_TREE has 2 PLOs: 1 satisfactory (80%) + 1 no data (null)
+    const stats = summaryBar.querySelectorAll('.plo-summary-stat');
+    expect(stats.length).toBe(2);
+    expect(stats[0].textContent).toContain('satisfactory');
+    expect(stats[1].textContent).toContain('no data');
+
+    // Summary bar appears before the tree
+    const tree = container.querySelector('ul.plo-tree');
+    expect(container.children[0]).toBe(summaryBar);
+    expect(container.children[1]).toBe(tree);
+  });
+});

--- a/tests/javascript/unit/plo_dashboard.test.js
+++ b/tests/javascript/unit/plo_dashboard.test.js
@@ -252,11 +252,6 @@ const SKELETON = `
     <option value="binary">Binary</option>
   </select>
 
-  <span id="statPloCount">-</span>
-  <span id="statMappedCloCount">-</span>
-  <span id="statOverallPassRate">-</span>
-  <span id="statMappingStatus">-</span>
-
   <button id="createPloBtn"></button>
   <button id="mapCloBtn"></button>
   <button id="expandAllBtn"></button>
@@ -420,11 +415,12 @@ describe('PloDashboard — filter loading', () => {
     await PloDashboard._loadPrograms();
 
     const sel = document.getElementById('ploProgramFilter');
-    expect(sel.options.length).toBe(2);
-    expect(sel.options[0].textContent).toBe('Biology BS');
-    // No localStorage entry → first program is default
-    expect(PloDashboard.currentProgramId).toBe('prog-1');
-    expect(sel.value).toBe('prog-1');
+    expect(sel.options.length).toBe(3); // All Programs + 2 programs
+    expect(sel.options[0].textContent).toBe('All Programs');
+    expect(sel.options[1].textContent).toBe('Biology BS');
+    // No localStorage entry → defaults to All Programs
+    expect(PloDashboard.currentProgramId).toBe('');
+    expect(sel.value).toBe('');
   });
 
   test('_loadPrograms honours localStorage when the stored id is still valid', async () => {
@@ -449,8 +445,8 @@ describe('PloDashboard — filter loading', () => {
       json: async () => ({ programs: [{ id: 'prog-1', name: 'Only One' }] }),
     });
     await PloDashboard._loadPrograms();
-    // Falls back to first valid id (using the `id` alias, not `program_id`)
-    expect(PloDashboard.currentProgramId).toBe('prog-1');
+    // Falls back to All Programs (empty string)
+    expect(PloDashboard.currentProgramId).toBe('');
   });
 
   test('_loadPrograms handles empty list gracefully', async () => {
@@ -519,14 +515,15 @@ describe('PloDashboard — loadTree + render', () => {
     delete global.fetch;
   });
 
-  test('no program selected → empty-state message, no fetch', async () => {
+  test('no program selected with no programs → empty-state message, no fetch', async () => {
     PloDashboard.currentProgramId = null;
+    PloDashboard.programs = [];
     global.fetch = jest.fn();
     await PloDashboard.loadTree();
     expect(global.fetch).not.toHaveBeenCalled();
     expect(
       document.getElementById('ploTreeContainer').textContent,
-    ).toMatch(/select a program/i);
+    ).toMatch(/no programs available/i);
   });
 
   test('successful load renders tree + populates stats', async () => {
@@ -563,16 +560,6 @@ describe('PloDashboard — loadTree + render', () => {
     // First section shows instructor name + pass count detail
     expect(sectionLeaves[0].textContent).toContain('Ada Lovelace');
     expect(sectionLeaves[0].textContent).toContain('27/30 passed');
-
-    // Stats populated
-    expect(document.getElementById('statPloCount').textContent).toBe('2');
-    expect(document.getElementById('statMappedCloCount').textContent).toBe('1');
-    expect(document.getElementById('statOverallPassRate').textContent).toBe(
-      '80%',
-    );
-    expect(document.getElementById('statMappingStatus').textContent).toBe(
-      'Published',
-    );
 
     // Version badge shows v2
     expect(
@@ -672,31 +659,97 @@ describe('PloDashboard — loadTree + render', () => {
     ).toMatch(/network down/);
   });
 
-  test('_updateStats(null) resets all stat cards to "-"', () => {
-    document.getElementById('statPloCount').textContent = 'old';
-    PloDashboard._updateStats(null);
-    expect(document.getElementById('statPloCount').textContent).toBe('-');
-    expect(document.getElementById('statOverallPassRate').textContent).toBe(
-      '-',
-    );
+  test('All Programs mode loads each program tree', async () => {
+    PloDashboard.currentProgramId = '';
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+      { program_id: 'prog-2', name: 'Chemistry BS' },
+    ];
+    // Mock PloTrend to avoid unrelated errors
+    global.PloTrend = { loadTrend: jest.fn() };
+
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url.includes('prog-1')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...SAMPLE_TREE,
+            program_id: 'prog-1',
+          }),
+        });
+      }
+      if (url.includes('prog-2')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...SAMPLE_TREE,
+            program_id: 'prog-2',
+            mapping: { id: 'm-2', version: 1, status: 'published' },
+            plos: [],
+          }),
+        });
+      }
+      return Promise.reject(new Error('unexpected URL'));
+    });
+
+    await PloDashboard.loadTree();
+
+    // Both program headings rendered
+    const headings = document.querySelectorAll('.plo-all-programs-heading');
+    expect(headings.length).toBe(2);
+    expect(headings[0].textContent).toContain('Biology BS');
+    expect(headings[1].textContent).toContain('Chemistry BS');
+
+    // First program has PLO tree, second shows "No PLOs defined."
+    const trees = document.querySelectorAll('ul.plo-tree');
+    expect(trees.length).toBe(1);
+    const emptyMsg = document.querySelector('p.text-muted');
+    expect(emptyMsg.textContent).toContain('No PLOs defined.');
+
+    // Program name label shows "All Programs"
+    expect(
+      document.getElementById('ploTreeProgramName').textContent,
+    ).toBe('All Programs');
+
+    // Version badge hidden in All Programs mode
+    expect(
+      document.getElementById('ploTreeVersionBadge').style.display,
+    ).toBe('none');
+
+    delete global.PloTrend;
   });
 
-  test('_updateStats shows em dash when no students_took anywhere', () => {
-    // Both PLOs have zero aggregate data → no pass rate to compute
-    PloDashboard._updateStats({
-      plos: [
-        { aggregate: { students_took: 0, students_passed: 0 } },
-        { aggregate: {} },
-      ],
-      mapping_status: 'draft',
+  test('All Programs mode skips programs that fail to load', async () => {
+    PloDashboard.currentProgramId = '';
+    PloDashboard.programs = [
+      { program_id: 'prog-bad', name: 'Failing Program' },
+      { program_id: 'prog-ok', name: 'Good Program' },
+    ];
+    global.PloTrend = { loadTrend: jest.fn() };
+
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url.includes('prog-bad')) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          ...SAMPLE_TREE,
+          program_id: 'prog-ok',
+        }),
+      });
     });
-    expect(document.getElementById('statOverallPassRate').textContent).toBe(
-      '—',
-    );
-    expect(document.getElementById('statMappingStatus').textContent).toBe(
-      'Draft',
-    );
+
+    await PloDashboard.loadTree();
+
+    // Only the successful program renders a heading
+    const headings = document.querySelectorAll('.plo-all-programs-heading');
+    expect(headings.length).toBe(1);
+    expect(headings[0].textContent).toContain('Good Program');
+
+    delete global.PloTrend;
   });
+
 });
 
 describe('PloDashboard — expand/collapse + event wiring', () => {

--- a/tests/javascript/unit/plo_dashboard.test.js
+++ b/tests/javascript/unit/plo_dashboard.test.js
@@ -1288,3 +1288,178 @@ describe('PloDashboard — _buildSummaryBar', () => {
     expect(container.children[1]).toBe(tree);
   });
 });
+
+describe('PloDashboard — _loadAllPrograms', () => {
+  beforeEach(() => {
+    setBody(SKELETON);
+    resetDashboardState();
+    PloDashboard._cacheSelectors();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('fetches all programs in parallel and renders sections', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+      { program_id: 'prog-2', name: 'Chemistry BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+    PloDashboard.currentTermId = '';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_TREE,
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    // Both programs should be rendered
+    const headings = document.querySelectorAll('.plo-all-programs-heading');
+    expect(headings.length).toBe(2);
+    expect(headings[0].textContent).toContain('Biology BS');
+    expect(headings[1].textContent).toContain('Chemistry BS');
+  });
+
+  test('handles failed fetch for one program gracefully', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+      { program_id: 'prog-2', name: 'Chemistry BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+
+    let callCount = 0;
+    global.fetch = jest.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => SAMPLE_TREE,
+        });
+      }
+      return Promise.reject(new Error('Network error'));
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    // Only the successful program should have a heading
+    const headings = document.querySelectorAll('.plo-all-programs-heading');
+    expect(headings.length).toBe(1);
+    expect(headings[0].textContent).toContain('Biology BS');
+  });
+
+  test('ignores stale results when generation counter changes', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+
+    let resolveFirst;
+    global.fetch = jest.fn(
+      () => new Promise((r) => { resolveFirst = r; }),
+    );
+
+    // Start first load
+    const p1 = PloDashboard._loadAllPrograms();
+
+    // Increment generation counter (simulates a second call starting)
+    PloDashboard._allProgramsGen = (PloDashboard._allProgramsGen || 0) + 1;
+
+    // Resolve first load
+    resolveFirst({
+      ok: true,
+      json: async () => SAMPLE_TREE,
+    });
+    await p1;
+
+    // Container should be empty — stale result ignored
+    const container = document.getElementById('ploTreeContainer');
+    expect(container.querySelectorAll('.plo-all-programs-heading').length).toBe(0);
+  });
+
+  test('renders version badge when mapping has version', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_TREE,
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    const badge = document.querySelector('.plo-all-programs-heading .badge');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe('v2');
+  });
+
+  test('collapsible toggle works on heading click', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_TREE,
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    const section = document.querySelector('.plo-program-section');
+    const heading = document.querySelector('.plo-all-programs-heading');
+    expect(section).not.toBeNull();
+
+    heading.click();
+    expect(section.classList.contains('collapsed')).toBe(true);
+
+    heading.click();
+    expect(section.classList.contains('collapsed')).toBe(false);
+  });
+
+  test('shows "No PLOs defined" for program with empty plos', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Empty Program' },
+    ];
+    PloDashboard.currentProgramId = '';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...SAMPLE_TREE,
+        plos: [],
+        mapping: null,
+      }),
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    const emptyMsg = document.querySelector('.text-muted.fst-italic');
+    expect(emptyMsg).not.toBeNull();
+    expect(emptyMsg.textContent).toBe('No PLOs defined.');
+  });
+
+  test('saves and restores displayMode per program', async () => {
+    PloDashboard.programs = [
+      { program_id: 'prog-1', name: 'Biology BS' },
+    ];
+    PloDashboard.currentProgramId = '';
+    PloDashboard.displayMode = 'percentage';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...SAMPLE_TREE,
+        assessment_display_mode: 'binary',
+      }),
+    });
+
+    await PloDashboard._loadAllPrograms();
+
+    // displayMode should be restored to original after rendering
+    expect(PloDashboard.displayMode).toBe('percentage');
+  });
+});

--- a/tests/javascript/unit/plo_dashboard.test.js
+++ b/tests/javascript/unit/plo_dashboard.test.js
@@ -264,7 +264,9 @@ const SKELETON = `
   <div id="ploModal">
     <form id="ploForm">
       <input id="ploModalId" type="hidden">
-      <input id="ploModalNumber">
+      <div id="ploModalNumberGroup">
+        <input id="ploModalNumber">
+      </div>
       <textarea id="ploModalDescription"></textarea>
       <span id="ploModalLabel"></span>
       <div id="ploModalAlert"></div>
@@ -887,6 +889,10 @@ describe('PloDashboard — PLO create/edit modal', () => {
       /new/i,
     );
     expect(document.getElementById('ploModalId').value).toBe('');
+    // PLO number group hidden in create mode (auto-assigned by server)
+    expect(
+      document.getElementById('ploModalNumberGroup').classList.contains('d-none'),
+    ).toBe(true);
     // No bootstrap present → fallback adds .show
     expect(
       document.getElementById('ploModal').classList.contains('show'),
@@ -907,11 +913,15 @@ describe('PloDashboard — PLO create/edit modal', () => {
     expect(document.getElementById('ploModalDescription').value).toBe(
       'Capstone assessment.',
     );
+    // PLO number group visible in edit mode
+    expect(
+      document.getElementById('ploModalNumberGroup').classList.contains('d-none'),
+    ).toBe(false);
   });
 
-  test('_submitPloForm POSTs, coerces plo_number to int, hides modal on success', async () => {
+  test('_submitPloForm POSTs without plo_number (auto-assigned), hides modal on success', async () => {
     document.getElementById('ploModalId').value = ''; // create mode
-    document.getElementById('ploModalNumber').value = '7';
+    document.getElementById('ploModalNumber').value = '';
     document.getElementById('ploModalDescription').value = 'New outcome';
 
     // Two fetches: POST for save, then GET from loadTree()
@@ -927,9 +937,8 @@ describe('PloDashboard — PLO create/edit modal', () => {
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toMatch(/\/api\/programs\/prog-1\/plos$/);
     expect(opts.method).toBe('POST');
-    // String "7" should have been parsed to integer 7 for the unique constraint
+    // Create mode: plo_number omitted — server auto-assigns
     expect(JSON.parse(opts.body)).toEqual({
-      plo_number: 7,
       description: 'New outcome',
     });
     expect(opts.headers['X-CSRFToken']).toBe('test-csrf-token');

--- a/tests/javascript/unit/plo_dashboard.test.js
+++ b/tests/javascript/unit/plo_dashboard.test.js
@@ -696,7 +696,9 @@ describe('PloDashboard — loadTree + render', () => {
 
     await PloDashboard.loadTree();
 
-    // Both program headings rendered
+    // Both program headings rendered (now inside collapsible sections)
+    const sections = document.querySelectorAll('.plo-program-section');
+    expect(sections.length).toBe(2);
     const headings = document.querySelectorAll('.plo-all-programs-heading');
     expect(headings.length).toBe(2);
     expect(headings[0].textContent).toContain('Biology BS');
@@ -707,6 +709,17 @@ describe('PloDashboard — loadTree + render', () => {
     expect(trees.length).toBe(1);
     const emptyMsg = document.querySelector('p.text-muted');
     expect(emptyMsg.textContent).toContain('No PLOs defined.');
+
+    // Programs are collapsible
+    const firstSection = sections[0];
+    expect(firstSection.querySelector('.plo-program-content')).not.toBeNull();
+    expect(firstSection.querySelector('.plo-program-toggle')).not.toBeNull();
+
+    // Clicking heading toggles collapsed state
+    headings[0].click();
+    expect(firstSection.classList.contains('collapsed')).toBe(true);
+    headings[0].click();
+    expect(firstSection.classList.contains('collapsed')).toBe(false);
 
     // Program name label shows "All Programs"
     expect(
@@ -1177,18 +1190,22 @@ describe('PloDashboard — small helpers', () => {
 // Summary bar
 // ---------------------------------------------------------------------------
 describe('PloDashboard — _buildSummaryBar', () => {
-  test('renders stats and progress bar for mixed PLO statuses', () => {
+  test('renders rows with sparkline slots for mixed PLO statuses', () => {
     const plos = [
-      { aggregate: { pass_rate: 90 } },
-      { aggregate: { pass_rate: 85 } },
-      { aggregate: { pass_rate: 60 } },
-      { aggregate: { pass_rate: null } },
+      { id: 'p1', plo_number: 1, aggregate: { pass_rate: 90 } },
+      { id: 'p2', plo_number: 2, aggregate: { pass_rate: 85 } },
+      { id: 'p3', plo_number: 3, aggregate: { pass_rate: 60 } },
+      { id: 'p4', plo_number: 4, aggregate: { pass_rate: null } },
     ];
 
     const bar = PloDashboard._buildSummaryBar(plos);
     expect(bar.className).toBe('plo-summary-bar');
 
-    // Stats: 2 satisfactory, 1 needs attention, 1 no data
+    // 3 rows: satisfactory, needs attention, no data
+    const rows = bar.querySelectorAll('.plo-summary-row');
+    expect(rows.length).toBe(3);
+
+    // Stats text in each row
     const stats = bar.querySelectorAll('.plo-summary-stat');
     expect(stats.length).toBe(3);
     expect(stats[0].textContent).toContain('2');
@@ -1197,6 +1214,16 @@ describe('PloDashboard — _buildSummaryBar', () => {
     expect(stats[1].textContent).toContain('needs attention');
     expect(stats[2].textContent).toContain('1');
     expect(stats[2].textContent).toContain('no data');
+
+    // Sparkline slots with PLO IDs
+    const slots = bar.querySelectorAll('.plo-summary-sparkline-slot');
+    expect(slots.length).toBe(4);
+    expect(slots[0].dataset.ploId).toBe('p1');
+    expect(slots[1].dataset.ploId).toBe('p2');
+
+    // Labels show PLO numbers
+    const labels = bar.querySelectorAll('.plo-summary-sparkline-label');
+    expect(labels[0].textContent).toBe('(1)');
 
     // Progress bar has 3 segments
     const segments = bar.querySelectorAll('.plo-summary-segment');
@@ -1208,11 +1235,13 @@ describe('PloDashboard — _buildSummaryBar', () => {
 
   test('omits zero-count categories', () => {
     const plos = [
-      { aggregate: { pass_rate: 90 } },
-      { aggregate: { pass_rate: 80 } },
+      { id: 'p1', plo_number: 1, aggregate: { pass_rate: 90 } },
+      { id: 'p2', plo_number: 2, aggregate: { pass_rate: 80 } },
     ];
 
     const bar = PloDashboard._buildSummaryBar(plos);
+    const rows = bar.querySelectorAll('.plo-summary-row');
+    expect(rows.length).toBe(1);
     const stats = bar.querySelectorAll('.plo-summary-stat');
     expect(stats.length).toBe(1);
     expect(stats[0].textContent).toContain('satisfactory');

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -969,6 +969,108 @@ describe("PloTrend controller", () => {
       const wrap = document.querySelector(".plo-trend-indicator");
       expect(wrap).toBeNull();
     });
+
+    test("injects sparklines into summary bar slots", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div class="plo-summary-bar">
+            <div class="plo-summary-row stat-pass">
+              <span class="plo-summary-stat">2 satisfactory</span>
+              <div class="plo-summary-sparkline-group">
+                <span class="plo-summary-sparkline-slot" data-plo-id="plo-1">
+                  <span class="plo-summary-sparkline-label">(1)</span>
+                </span>
+                <span class="plo-summary-sparkline-slot" data-plo-id="plo-2">
+                  <span class="plo-summary-sparkline-label">(2)</span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+          </div>
+          <div data-plo-id="plo-2">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "PLO One",
+            trend: [{ pass_rate: 70 }, { pass_rate: 85 }],
+            clos: [],
+          },
+          {
+            id: "plo-2",
+            plo_number: 2,
+            description: "PLO Two",
+            trend: [{ pass_rate: 60 }, { pass_rate: 75 }],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      // Sparkline canvases should be inserted in the summary bar slots
+      const slots = document.querySelectorAll(".plo-summary-sparkline-slot");
+      expect(slots.length).toBe(2);
+      expect(slots[0].querySelector(".plo-sparkline")).not.toBeNull();
+      expect(slots[1].querySelector(".plo-sparkline")).not.toBeNull();
+      // Labels preserved
+      expect(
+        slots[0].querySelector(".plo-summary-sparkline-label").textContent,
+      ).toBe("(1)");
+    });
+
+    test("skips summary bar slots with insufficient trend data", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div class="plo-summary-bar">
+            <div class="plo-summary-row stat-nodata">
+              <div class="plo-summary-sparkline-group">
+                <span class="plo-summary-sparkline-slot" data-plo-id="plo-3">
+                  <span class="plo-summary-sparkline-label">(3)</span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-3",
+            plo_number: 3,
+            description: "No data PLO",
+            trend: [{ pass_rate: null }],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const slot = document.querySelector(".plo-summary-sparkline-slot");
+      expect(slot.querySelector(".plo-sparkline")).toBeNull();
+    });
   });
 
   describe("_toggleTrendPanel", () => {

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -41,6 +41,7 @@ const {
   createSparkline,
   createTrendPanel,
   createCompositionBar,
+  computeYRange,
   PloTrend,
 } = require("../../../static/plo_trend");
 
@@ -190,28 +191,40 @@ describe("createTrendPanel", () => {
     expect(panel.className).toBe("plo-trend-panel");
   });
 
-  test("contains a close button", () => {
+  test("contains a visibility toggle button", () => {
     const panel = createTrendPanel(points, terms);
-    const closeBtn = panel.querySelector(".plo-trend-panel-close");
-    expect(closeBtn).not.toBeNull();
-    expect(closeBtn.tagName).toBe("BUTTON");
-    expect(closeBtn.title).toBe("Close trend chart");
+    const toggleBtn = panel.querySelector(".plo-trend-panel-toggle");
+    expect(toggleBtn).not.toBeNull();
+    expect(toggleBtn.tagName).toBe("BUTTON");
+    expect(toggleBtn.title).toBe("Hide trend chart");
   });
 
-  test("close button removes the panel from DOM", () => {
+  test("toggle button hides and shows the panel body", () => {
     const parent = document.createElement("div");
     const panel = createTrendPanel(points, terms);
     parent.appendChild(panel);
-    expect(parent.children.length).toBe(1);
 
-    const closeBtn = panel.querySelector(".plo-trend-panel-close");
-    closeBtn.click();
-    expect(parent.children.length).toBe(0);
+    const toggleBtn = panel.querySelector(".plo-trend-panel-toggle");
+    const body = panel.querySelector(".plo-trend-panel-body");
+    expect(body).not.toBeNull();
+    expect(body.style.display).toBe("");
+
+    // First click: hide
+    toggleBtn.click();
+    expect(body.style.display).toBe("none");
+    expect(panel.classList.contains("plo-trend-panel--collapsed")).toBe(true);
+
+    // Second click: show
+    toggleBtn.click();
+    expect(body.style.display).toBe("");
+    expect(panel.classList.contains("plo-trend-panel--collapsed")).toBe(false);
   });
 
-  test("contains a canvas element", () => {
+  test("contains a canvas element inside body", () => {
     const panel = createTrendPanel(points, terms);
-    const canvas = panel.querySelector("canvas");
+    const body = panel.querySelector(".plo-trend-panel-body");
+    expect(body).not.toBeNull();
+    const canvas = body.querySelector("canvas");
     expect(canvas).not.toBeNull();
   });
 
@@ -223,6 +236,48 @@ describe("createTrendPanel", () => {
   test("shows no-data message when points are null", () => {
     const panel = createTrendPanel(null, terms);
     expect(panel.textContent).toContain("No trend data available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeYRange
+// ---------------------------------------------------------------------------
+describe("computeYRange", () => {
+  test("returns 0-100 for empty datasets", () => {
+    expect(computeYRange([])).toEqual({ min: 0, max: 100 });
+  });
+
+  test("returns 0-100 for all-NaN data", () => {
+    expect(computeYRange([{ data: [NaN, NaN] }])).toEqual({ min: 0, max: 100 });
+  });
+
+  test("zooms into data range with padding", () => {
+    const result = computeYRange([{ data: [60, 70, 80] }]);
+    expect(result.min).toBeLessThanOrEqual(57);
+    expect(result.max).toBeGreaterThanOrEqual(83);
+    expect(result.min).toBeGreaterThanOrEqual(0);
+    expect(result.max).toBeLessThanOrEqual(100);
+  });
+
+  test("clamps to 0-100 bounds", () => {
+    const result = computeYRange([{ data: [2, 98] }]);
+    expect(result.min).toBeGreaterThanOrEqual(0);
+    expect(result.max).toBeLessThanOrEqual(100);
+  });
+
+  test("handles multiple datasets", () => {
+    const result = computeYRange([
+      { data: [60, 70] },
+      { data: [50, 90] },
+    ]);
+    expect(result.min).toBeLessThanOrEqual(44);
+    expect(result.max).toBeGreaterThanOrEqual(96);
+  });
+
+  test("handles single-value data without zero span", () => {
+    const result = computeYRange([{ data: [75] }]);
+    expect(result.min).toBeLessThan(75);
+    expect(result.max).toBeGreaterThan(75);
   });
 });
 
@@ -351,9 +406,10 @@ describe("createTrendPanel with CLO overlays", () => {
     },
   ];
 
-  test("renders CLO composition bar when CLOs provided", () => {
+  test("renders CLO composition bar inside body when CLOs provided", () => {
     const panel = createTrendPanel(points, terms, { clos });
-    const compBar = panel.querySelector(".plo-composition-bar");
+    const body = panel.querySelector(".plo-trend-panel-body");
+    const compBar = body.querySelector(".plo-composition-bar");
     expect(compBar).not.toBeNull();
   });
 
@@ -389,6 +445,109 @@ describe("createTrendPanel with CLO overlays", () => {
     const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
     const legend = chartCall[1].options.plugins.legend;
     expect(legend.display).toBe(false);
+  });
+
+  test("interactive legend: onClick handler solos clicked dataset", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const legendOnClick = chartCall[1].options.plugins.legend.onClick;
+    expect(typeof legendOnClick).toBe("function");
+  });
+
+  test("Y-axis uses auto-zoom instead of 0-100", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const yScale = chartCall[1].options.scales.y;
+    // Should NOT be 0/100 since data is 70-95 range
+    expect(yScale.min).not.toBe(0);
+  });
+
+  test("discontinuityLines plugin renders subtle hairlines without text", () => {
+    Chart.mockClear();
+    const discs = [
+      {
+        term_index: 1,
+        term_id: "t2",
+        type: "clo_change",
+        added: [{ clo_id: "c1", label: "CS201/2" }],
+        removed: [{ clo_id: "c2", label: "CS101/1" }],
+      },
+    ];
+    createTrendPanel(points, terms, { discontinuities: discs });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const discPlugin = chartCall[1].plugins.find((p) => p.id === "discontinuityLines");
+    expect(discPlugin).toBeDefined();
+    // Execute the afterDraw to verify it doesn't call fillText (no text labels)
+    const mockCtx = {
+      save: jest.fn(),
+      restore: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      fillText: jest.fn(),
+      setLineDash: jest.fn(),
+      set strokeStyle(_) {},
+      set lineWidth(_) {},
+    };
+    const mockChart = {
+      scales: {
+        x: { getPixelForValue: jest.fn().mockReturnValue(50) },
+        y: { getPixelForValue: jest.fn().mockReturnValue(50) },
+      },
+      chartArea: { top: 0, bottom: 100, left: 0, right: 200 },
+      ctx: mockCtx,
+    };
+    discPlugin.afterDraw(mockChart);
+    expect(mockCtx.stroke).toHaveBeenCalled();
+    // Should NOT render text labels — details are in tooltip afterBody
+    expect(mockCtx.fillText).not.toHaveBeenCalled();
+  });
+
+  test("tooltip afterBody shows course changes at discontinuity terms", () => {
+    Chart.mockClear();
+    const discs = [
+      {
+        term_index: 1,
+        term_id: "t2",
+        type: "clo_change",
+        added: [{ clo_id: "c1", label: "CS201/2" }],
+        removed: [{ clo_id: "c2", label: "CS101/1" }],
+      },
+    ];
+    createTrendPanel(points, terms, { discontinuities: discs });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const afterBody = chartCall[1].options.plugins.tooltip.callbacks.afterBody;
+
+    // At term index 1 (where discontinuity is)
+    const result = afterBody([{ dataIndex: 1 }]);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.join(" ")).toContain("CS201/2");
+    expect(result.join(" ")).toContain("CS101/1");
+  });
+
+  test("tooltip afterBody returns empty string at non-discontinuity terms", () => {
+    Chart.mockClear();
+    const discs = [
+      { term_index: 1, added: [], removed: [] },
+    ];
+    createTrendPanel(points, terms, { discontinuities: discs });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const afterBody = chartCall[1].options.plugins.tooltip.callbacks.afterBody;
+
+    // At term index 0 (no discontinuity)
+    expect(afterBody([{ dataIndex: 0 }])).toBe("");
+  });
+
+  test("composition bar is inside panel body div", () => {
+    const panel = createTrendPanel(points, terms, { clos });
+    const body = panel.querySelector(".plo-trend-panel-body");
+    expect(body).not.toBeNull();
+    const compBar = body.querySelector(".plo-composition-bar");
+    expect(compBar).not.toBeNull();
   });
 
   test("discontinuityLines plugin is passed to Chart", () => {

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -191,8 +191,8 @@ describe("createSparkline", () => {
 
   test("canvas has correct dimensions and class", () => {
     const canvas = createSparkline(points, terms);
-    expect(canvas.width).toBe(90);
-    expect(canvas.height).toBe(28);
+    expect(canvas.width).toBe(100);
+    expect(canvas.height).toBe(32);
     expect(canvas.className).toBe("plo-sparkline");
   });
 

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -38,6 +38,7 @@ global.requestAnimationFrame = (cb) => cb();
 const {
   getTrendDirection,
   getTrendArrow,
+  getTrendDelta,
   createSparkline,
   createTrendPanel,
   createCompositionBar,
@@ -136,6 +137,40 @@ describe("getTrendArrow", () => {
       arrow: "",
       cssClass: "trend-none",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTrendDelta
+// ---------------------------------------------------------------------------
+describe("getTrendDelta", () => {
+  test("returns rounded delta between first and last valid points", () => {
+    const pts = [{ pass_rate: 70 }, { pass_rate: 75 }, { pass_rate: 82.6 }];
+    expect(getTrendDelta(pts)).toBe(13);
+  });
+
+  test("returns negative delta when trending down", () => {
+    const pts = [{ pass_rate: 90 }, { pass_rate: 80 }];
+    expect(getTrendDelta(pts)).toBe(-10);
+  });
+
+  test("returns 0 for flat trend", () => {
+    const pts = [{ pass_rate: 70 }, { pass_rate: 70 }];
+    expect(getTrendDelta(pts)).toBe(0);
+  });
+
+  test("returns null for single data point", () => {
+    expect(getTrendDelta([{ pass_rate: 80 }])).toBeNull();
+  });
+
+  test("returns null for empty or null input", () => {
+    expect(getTrendDelta([])).toBeNull();
+    expect(getTrendDelta(null)).toBeNull();
+  });
+
+  test("skips null points", () => {
+    const pts = [{ pass_rate: 60 }, null, { pass_rate: null }, { pass_rate: 80 }];
+    expect(getTrendDelta(pts)).toBe(20);
   });
 });
 
@@ -771,7 +806,7 @@ describe("PloTrend controller", () => {
       PloTrend.injectSparklines(); // should not throw
     });
 
-    test("injects sparkline into PLO node", () => {
+    test("injects trend indicator into PLO node", () => {
       document.body.innerHTML = `
         <div id="ploTreeContainer">
           <div data-plo-id="plo-1">
@@ -802,12 +837,14 @@ describe("PloTrend controller", () => {
 
       PloTrend.injectSparklines();
 
-      const wrap = document.querySelector(".plo-sparkline-wrap");
+      const wrap = document.querySelector(".plo-trend-indicator");
       expect(wrap).not.toBeNull();
-      expect(wrap.querySelector(".plo-sparkline")).not.toBeNull();
+      expect(wrap.querySelector(".plo-trend-arrow")).not.toBeNull();
+      expect(wrap.querySelector(".plo-trend-delta")).not.toBeNull();
+      expect(wrap.querySelector(".plo-trend-delta").textContent).toBe("+10%");
     });
 
-    test("injects sparkline into CLO node", () => {
+    test("injects trend indicator into CLO node", () => {
       document.body.innerHTML = `
         <div id="ploTreeContainer">
           <div data-plo-id="plo-1">
@@ -852,16 +889,17 @@ describe("PloTrend controller", () => {
       PloTrend.injectSparklines();
 
       const cloNode = document.querySelector('[data-clo-id="clo-1"]');
-      const wrap = cloNode.querySelector(".plo-sparkline-wrap");
+      const wrap = cloNode.querySelector(".plo-trend-indicator");
       expect(wrap).not.toBeNull();
+      expect(wrap.querySelector(".plo-trend-delta").textContent).toBe("+15%");
     });
 
-    test("removes existing sparklines before re-injecting", () => {
+    test("removes existing trend indicators before re-injecting", () => {
       document.body.innerHTML = `
         <div id="ploTreeContainer">
           <div data-plo-id="plo-1">
             <div class="plo-tree-header">
-              <span class="plo-sparkline-wrap">old</span>
+              <span class="plo-trend-indicator">old</span>
               <div class="plo-tree-meta"></div>
             </div>
             <div class="plo-trend-panel">old panel</div>
@@ -887,8 +925,8 @@ describe("PloTrend controller", () => {
 
       PloTrend.injectSparklines();
 
-      // Old sparkline-wrap with "old" text should be replaced per-node
-      const wraps = document.querySelectorAll(".plo-sparkline-wrap");
+      // Old trend-indicator with "old" text should be replaced per-node
+      const wraps = document.querySelectorAll(".plo-trend-indicator");
       wraps.forEach((w) => {
         expect(w.textContent).not.toBe("old");
       });
@@ -928,7 +966,7 @@ describe("PloTrend controller", () => {
 
       PloTrend.injectSparklines();
 
-      const wrap = document.querySelector(".plo-sparkline-wrap");
+      const wrap = document.querySelector(".plo-trend-indicator");
       expect(wrap).toBeNull();
     });
   });

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -1206,6 +1206,176 @@ describe("PloTrend controller", () => {
       const indicator = document.querySelector(".plo-trend-indicator");
       expect(indicator).not.toBeNull();
     });
+
+    test("trend badge in tree node reflects data up to selectedTermId only", () => {
+      // Trend: 70 → 65 → 80.  Full data = +10% (up).
+      // Selected term index 1 (term-2) ⇒ 70 → 65 = -5% (down).
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta">
+                <span class="plo-assessment-badge">65%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.selectedTermId = "term-2";
+      PloTrend.trendData = {
+        terms: [
+          { term_id: "term-1", term_name: "Fall 2024", is_current: false },
+          { term_id: "term-2", term_name: "Spring 2025", is_current: false },
+          { term_id: "term-3", term_name: "Fall 2025", is_current: true },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "PLO One",
+            trend: [
+              { pass_rate: 70 },
+              { pass_rate: 65 },
+              { pass_rate: 80 },
+            ],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const delta = document.querySelector(".plo-trend-delta");
+      expect(delta).not.toBeNull();
+      // Should show -5% (70→65), NOT +10% (70→80)
+      expect(delta.textContent).toBe("-5%");
+      // Arrow should indicate "down"
+      const arrow = document.querySelector(".plo-trend-arrow");
+      expect(arrow).not.toBeNull();
+      expect(arrow.textContent).toBe("↓");
+    });
+
+    test("summary bar badge reflects data up to selectedTermId only", () => {
+      // Trend: 70 → 65 → 80.  Full data = +10% (up).
+      // Selected term index 1 (term-2) ⇒ 70 → 65 = -5% (down).
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div class="plo-summary-bar">
+            <div class="plo-summary-row stat-pass">
+              <div class="plo-summary-sparkline-group">
+                <span class="plo-summary-sparkline-slot" data-plo-id="plo-1">
+                  <span class="plo-summary-sparkline-label">(1)</span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta">
+                <span class="plo-assessment-badge">65%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.selectedTermId = "term-2";
+      PloTrend.trendData = {
+        terms: [
+          { term_id: "term-1", term_name: "Fall 2024", is_current: false },
+          { term_id: "term-2", term_name: "Spring 2025", is_current: false },
+          { term_id: "term-3", term_name: "Fall 2025", is_current: true },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "PLO One",
+            trend: [
+              { pass_rate: 70 },
+              { pass_rate: 65 },
+              { pass_rate: 80 },
+            ],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      // Check the summary bar badge (not the tree node badge)
+      const slot = document.querySelector(".plo-summary-sparkline-slot");
+      const badge = slot.querySelector(".plo-trend-indicator");
+      expect(badge).not.toBeNull();
+      const delta = badge.querySelector(".plo-trend-delta");
+      expect(delta).not.toBeNull();
+      // Should show -5% (70→65), NOT +10% (70→80)
+      expect(delta.textContent).toBe("-5%");
+      const arrow = badge.querySelector(".plo-trend-arrow");
+      expect(arrow.textContent).toBe("↓");
+    });
+
+    test("CLO trend badge reflects data up to selectedTermId only", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+            <div data-clo-id="clo-1">
+              <div class="plo-tree-header">
+                <div class="plo-tree-meta">
+                  <span class="plo-assessment-badge">60%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.selectedTermId = "term-2";
+      PloTrend.trendData = {
+        terms: [
+          { term_id: "term-1", term_name: "Fall 2024", is_current: false },
+          { term_id: "term-2", term_name: "Spring 2025", is_current: false },
+          { term_id: "term-3", term_name: "Fall 2025", is_current: true },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "PLO One",
+            trend: [
+              { pass_rate: 80 },
+              { pass_rate: 75 },
+              { pass_rate: 90 },
+            ],
+            clos: [
+              {
+                outcome_id: "clo-1",
+                clo_number: 1,
+                course_number: "CS101",
+                description: "Test CLO",
+                trend: [
+                  { pass_rate: 60 },
+                  { pass_rate: 50 },
+                  { pass_rate: 70 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const cloNode = document.querySelector('[data-clo-id="clo-1"]');
+      const delta = cloNode.querySelector(".plo-trend-delta");
+      expect(delta).not.toBeNull();
+      // Should show -10% (60→50), NOT +10% (60→70)
+      expect(delta.textContent).toBe("-10%");
+    });
   });
 
   describe("_toggleTrendPanel", () => {

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -859,12 +859,12 @@ describe("PloTrend controller", () => {
     test("removes existing sparklines before re-injecting", () => {
       document.body.innerHTML = `
         <div id="ploTreeContainer">
-          <span class="plo-sparkline-wrap">old</span>
-          <div class="plo-trend-panel">old panel</div>
           <div data-plo-id="plo-1">
             <div class="plo-tree-header">
+              <span class="plo-sparkline-wrap">old</span>
               <div class="plo-tree-meta"></div>
             </div>
+            <div class="plo-trend-panel">old panel</div>
           </div>
         </div>
       `;
@@ -887,10 +887,15 @@ describe("PloTrend controller", () => {
 
       PloTrend.injectSparklines();
 
-      // Old sparkline-wrap with "old" text should be gone
+      // Old sparkline-wrap with "old" text should be replaced per-node
       const wraps = document.querySelectorAll(".plo-sparkline-wrap");
       wraps.forEach((w) => {
         expect(w.textContent).not.toBe("old");
+      });
+      // Old trend panel should also be removed
+      const panels = document.querySelectorAll(".plo-trend-panel");
+      panels.forEach((p) => {
+        expect(p.textContent).not.toBe("old panel");
       });
     });
 

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -616,7 +616,7 @@ describe("createTrendPanel with CLO overlays", () => {
       dataset: { label: "PLO Pass Rate %" },
     };
     // Points have no students_took, so just percentage
-    expect(labelCb(ploItem)).toBe("PLO: 80%");
+    expect(labelCb(ploItem)).toBe("PLO Pass Rate %: 80%");
   });
 
   test("tooltip label callback shows CLO data", () => {

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -68,14 +68,24 @@ describe("getTrendDirection", () => {
     ).toBe("none");
   });
 
-  test("returns 'up' when last > first by >= 2", () => {
-    const points = [{ pass_rate: 60 }, { pass_rate: 70 }, { pass_rate: 80 }];
+  test("returns 'up' when last > first by 2–9 pp", () => {
+    const points = [{ pass_rate: 70 }, { pass_rate: 75 }];
     expect(getTrendDirection(points)).toBe("up");
   });
 
-  test("returns 'down' when last < first by >= 2", () => {
-    const points = [{ pass_rate: 90 }, { pass_rate: 70 }, { pass_rate: 60 }];
+  test("returns 'strong-up' when last > first by >= 10 pp", () => {
+    const points = [{ pass_rate: 60 }, { pass_rate: 70 }, { pass_rate: 80 }];
+    expect(getTrendDirection(points)).toBe("strong-up");
+  });
+
+  test("returns 'down' when last < first by 2–9 pp", () => {
+    const points = [{ pass_rate: 80 }, { pass_rate: 75 }];
     expect(getTrendDirection(points)).toBe("down");
+  });
+
+  test("returns 'strong-down' when last < first by >= 10 pp", () => {
+    const points = [{ pass_rate: 90 }, { pass_rate: 70 }, { pass_rate: 60 }];
+    expect(getTrendDirection(points)).toBe("strong-down");
   });
 
   test("returns 'flat' when difference < 2", () => {
@@ -89,15 +99,15 @@ describe("getTrendDirection", () => {
   });
 
   test("skips null entries when computing direction", () => {
-    const points = [{ pass_rate: 50 }, null, { pass_rate: 80 }];
+    const points = [{ pass_rate: 70 }, null, { pass_rate: 78 }];
     expect(getTrendDirection(points)).toBe("up");
   });
 
   test("skips entries with null pass_rate", () => {
     const points = [
-      { pass_rate: 90 },
+      { pass_rate: 80 },
       { pass_rate: null },
-      { pass_rate: 70 },
+      { pass_rate: 75 },
     ];
     expect(getTrendDirection(points)).toBe("down");
   });
@@ -111,10 +121,24 @@ describe("getTrendArrow", () => {
     expect(getTrendArrow("up")).toEqual({ arrow: "↑", cssClass: "trend-up" });
   });
 
+  test("strong-up → ⬆ with trend-strong-up class", () => {
+    expect(getTrendArrow("strong-up")).toEqual({
+      arrow: "⬆",
+      cssClass: "trend-strong-up",
+    });
+  });
+
   test("down → ↓ with trend-down class", () => {
     expect(getTrendArrow("down")).toEqual({
       arrow: "↓",
       cssClass: "trend-down",
+    });
+  });
+
+  test("strong-down → ⬇ with trend-strong-down class", () => {
+    expect(getTrendArrow("strong-down")).toEqual({
+      arrow: "⬇",
+      cssClass: "trend-strong-down",
     });
   });
 
@@ -1029,6 +1053,11 @@ describe("PloTrend controller", () => {
       expect(slots.length).toBe(2);
       expect(slots[0].querySelector(".plo-sparkline")).not.toBeNull();
       expect(slots[1].querySelector(".plo-sparkline")).not.toBeNull();
+      // Trend badges should be inserted
+      const badge0 = slots[0].querySelector(".plo-trend-indicator");
+      expect(badge0).not.toBeNull();
+      expect(badge0.querySelector(".plo-trend-arrow")).not.toBeNull();
+      expect(badge0.querySelector(".plo-trend-delta")).not.toBeNull();
       // Labels preserved
       expect(
         slots[0].querySelector(".plo-summary-sparkline-label").textContent,

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -40,6 +40,7 @@ const {
   getTrendArrow,
   createSparkline,
   createTrendPanel,
+  createCompositionBar,
   PloTrend,
 } = require("../../../static/plo_trend");
 
@@ -222,6 +223,277 @@ describe("createTrendPanel", () => {
   test("shows no-data message when points are null", () => {
     const panel = createTrendPanel(null, terms);
     expect(panel.textContent).toContain("No trend data available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCompositionBar
+// ---------------------------------------------------------------------------
+describe("createCompositionBar", () => {
+  const terms = [
+    { term_name: "Fall 2024", is_current: false },
+    { term_name: "Spring 2025", is_current: false },
+  ];
+
+  test("returns a div with plo-composition-bar class", () => {
+    const bar = createCompositionBar([], terms);
+    expect(bar.tagName).toBe("DIV");
+    expect(bar.className).toBe("plo-composition-bar");
+  });
+
+  test("creates one cell per term", () => {
+    const clos = [
+      {
+        course_number: "CS101",
+        trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const cells = bar.querySelectorAll(".plo-comp-cell");
+    expect(cells.length).toBe(2);
+  });
+
+  test("shows empty dots for terms with no data", () => {
+    const clos = [
+      {
+        course_number: "CS101",
+        trend: [null, { pass_rate: 90 }],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const emptyDots = bar.querySelectorAll(".plo-comp-empty");
+    expect(emptyDots.length).toBe(1);
+  });
+
+  test("shows colored dots for terms with data", () => {
+    const clos = [
+      {
+        course_number: "CS101",
+        trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const dots = bar.querySelectorAll(".plo-comp-dot:not(.plo-comp-empty)");
+    expect(dots.length).toBe(2);
+  });
+
+  test("includes legend with course names", () => {
+    const clos = [
+      {
+        course_number: "CS101",
+        trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+      },
+      {
+        course_number: "CS201",
+        trend: [{ pass_rate: 70 }, null],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const legend = bar.querySelector(".plo-comp-legend");
+    expect(legend).not.toBeNull();
+    expect(legend.textContent).toContain("CS101");
+    expect(legend.textContent).toContain("CS201");
+  });
+
+  test("handles CLOs with null pass_rate as no data", () => {
+    const clos = [
+      {
+        course_number: "CS101",
+        trend: [{ pass_rate: null }, { pass_rate: 80 }],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const emptyDots = bar.querySelectorAll(".plo-comp-empty");
+    expect(emptyDots.length).toBe(1);
+  });
+
+  test("handles missing course_number gracefully", () => {
+    const clos = [
+      {
+        trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+      },
+    ];
+    const bar = createCompositionBar(clos, terms);
+    const legend = bar.querySelector(".plo-comp-legend");
+    expect(legend.textContent).toContain("?");
+  });
+
+  test("no legend when no CLOs provided", () => {
+    const bar = createCompositionBar([], terms);
+    const legend = bar.querySelector(".plo-comp-legend");
+    expect(legend).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTrendPanel — CLO overlays, discontinuities, composition bar
+// ---------------------------------------------------------------------------
+describe("createTrendPanel with CLO overlays", () => {
+  const terms = [
+    { term_name: "Fall 2024", term_id: "t1", is_current: false },
+    { term_name: "Spring 2025", term_id: "t2", is_current: false },
+  ];
+  const points = [{ pass_rate: 80 }, { pass_rate: 90 }];
+  const clos = [
+    {
+      outcome_id: "clo-1",
+      clo_number: 1,
+      course_number: "CS101",
+      description: "Test CLO",
+      trend: [{ pass_rate: 75 }, { pass_rate: 85 }],
+    },
+    {
+      outcome_id: "clo-2",
+      clo_number: 2,
+      course_number: "CS201",
+      description: "Another CLO",
+      trend: [{ pass_rate: 70 }, { pass_rate: 95 }],
+    },
+  ];
+
+  test("renders CLO composition bar when CLOs provided", () => {
+    const panel = createTrendPanel(points, terms, { clos });
+    const compBar = panel.querySelector(".plo-composition-bar");
+    expect(compBar).not.toBeNull();
+  });
+
+  test("does not render composition bar when no CLOs", () => {
+    const panel = createTrendPanel(points, terms, { clos: [] });
+    const compBar = panel.querySelector(".plo-composition-bar");
+    expect(compBar).toBeNull();
+  });
+
+  test("Chart constructor receives multiple datasets for CLO overlays", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    // Chart should have been called with PLO + 2 CLO datasets = 3
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const datasets = chartCall[1].data.datasets;
+    expect(datasets.length).toBe(3); // 1 PLO + 2 CLO
+    expect(datasets[0].label).toBe("PLO Pass Rate %");
+    expect(datasets[1].label).toBe("CS101 CLO 1");
+    expect(datasets[2].label).toBe("CS201 CLO 2");
+  });
+
+  test("Chart legend is displayed when CLOs present", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const legend = chartCall[1].options.plugins.legend;
+    expect(legend.display).toBe(true);
+  });
+
+  test("Chart legend is hidden when no CLOs", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos: [] });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const legend = chartCall[1].options.plugins.legend;
+    expect(legend.display).toBe(false);
+  });
+
+  test("discontinuityLines plugin is passed to Chart", () => {
+    Chart.mockClear();
+    const discs = [
+      {
+        term_index: 1,
+        term_id: "t2",
+        type: "clo_change",
+        added: [{ clo_id: "c1", label: "CS201/2" }],
+        removed: [],
+      },
+    ];
+    createTrendPanel(points, terms, { discontinuities: discs });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const pluginIds = chartCall[1].plugins.map((p) => p.id);
+    expect(pluginIds).toContain("discontinuityLines");
+    expect(pluginIds).toContain("thresholdLine");
+  });
+
+  test("onClick handler sets term filter when data point clicked", () => {
+    document.body.innerHTML = `
+      <select id="ploTermFilter">
+        <option value="">All</option>
+        <option value="t1">Fall 2024</option>
+        <option value="t2">Spring 2025</option>
+      </select>
+    `;
+
+    Chart.mockClear();
+    createTrendPanel(points, terms, {});
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const onClick = chartCall[1].options.onClick;
+
+    // Simulate click on second data point
+    const changeSpy = jest.fn();
+    const termFilter = document.getElementById("ploTermFilter");
+    termFilter.addEventListener("change", changeSpy);
+
+    onClick({}, [{ index: 1 }]);
+    expect(termFilter.value).toBe("t2");
+    expect(changeSpy).toHaveBeenCalled();
+  });
+
+  test("onClick handler does nothing when no elements clicked", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, {});
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const onClick = chartCall[1].options.onClick;
+    // Should not throw
+    onClick({}, []);
+    onClick({}, null);
+  });
+
+  test("tooltip label callback shows PLO data with student counts", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const labelCb = chartCall[1].options.plugins.tooltip.callbacks.label;
+
+    // PLO dataset (index 0)
+    const ploItem = {
+      raw: 80,
+      dataIndex: 0,
+      datasetIndex: 0,
+      dataset: { label: "PLO Pass Rate %" },
+    };
+    // Points have no students_took, so just percentage
+    expect(labelCb(ploItem)).toBe("PLO: 80%");
+  });
+
+  test("tooltip label callback shows CLO data", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const labelCb = chartCall[1].options.plugins.tooltip.callbacks.label;
+
+    // CLO dataset (index 1 = first CLO)
+    const cloItem = {
+      raw: 75,
+      dataIndex: 0,
+      datasetIndex: 1,
+      dataset: { label: "CS101 CLO 1" },
+    };
+    expect(labelCb(cloItem)).toBe("CS101 CLO 1: 75%");
+  });
+
+  test("tooltip filter removes null/NaN entries", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, {});
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const filterCb = chartCall[1].options.plugins.tooltip.callbacks.filter;
+
+    expect(filterCb({ raw: 80 })).toBe(true);
+    expect(filterCb({ raw: NaN })).toBe(false);
+    expect(filterCb({ raw: null })).toBe(false);
+  });
+
+  test("tooltip label returns null for NaN values", () => {
+    Chart.mockClear();
+    createTrendPanel(points, terms, { clos });
+    const chartCall = Chart.mock.calls[Chart.mock.calls.length - 1];
+    const labelCb = chartCall[1].options.plugins.tooltip.callbacks.label;
+
+    expect(labelCb({ raw: NaN, datasetIndex: 0, dataIndex: 0 })).toBeNull();
   });
 });
 

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -1,0 +1,523 @@
+/**
+ * Unit tests for static/plo_trend.js.
+ *
+ * Covers:
+ *  - getTrendDirection: trend detection from data points
+ *  - getTrendArrow: arrow character + CSS class mapping
+ *  - createSparkline: DOM element creation (Chart.js mocked)
+ *  - createTrendPanel: panel DOM structure + close button
+ *  - PloTrend controller: loadTrend, injectSparklines, toggle panel
+ */
+
+// Mock Chart.js globally before requiring the module
+global.Chart = jest.fn().mockImplementation(() => ({
+  destroy: jest.fn(),
+  update: jest.fn(),
+  scales: { y: { getPixelForValue: jest.fn().mockReturnValue(50) } },
+  ctx: {
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    stroke: jest.fn(),
+    fillText: jest.fn(),
+    set strokeStyle(_) {},
+    set lineWidth(_) {},
+    set fillStyle(_) {},
+    set font(_) {},
+    setLineDash: jest.fn(),
+  },
+  chartArea: { left: 0, right: 100 },
+}));
+
+// Execute requestAnimationFrame callbacks synchronously so Chart.js
+// rendering code is exercised for coverage.
+global.requestAnimationFrame = (cb) => cb();
+
+const {
+  getTrendDirection,
+  getTrendArrow,
+  createSparkline,
+  createTrendPanel,
+  PloTrend,
+} = require("../../../static/plo_trend");
+
+// ---------------------------------------------------------------------------
+// getTrendDirection
+// ---------------------------------------------------------------------------
+describe("getTrendDirection", () => {
+  test("returns 'none' for empty array", () => {
+    expect(getTrendDirection([])).toBe("none");
+  });
+
+  test("returns 'none' for single point", () => {
+    expect(getTrendDirection([{ pass_rate: 80 }])).toBe("none");
+  });
+
+  test("returns 'none' when all points are null", () => {
+    expect(getTrendDirection([null, null, null])).toBe("none");
+  });
+
+  test("returns 'none' when all pass_rates are null", () => {
+    expect(
+      getTrendDirection([{ pass_rate: null }, { pass_rate: null }])
+    ).toBe("none");
+  });
+
+  test("returns 'up' when last > first by >= 2", () => {
+    const points = [{ pass_rate: 60 }, { pass_rate: 70 }, { pass_rate: 80 }];
+    expect(getTrendDirection(points)).toBe("up");
+  });
+
+  test("returns 'down' when last < first by >= 2", () => {
+    const points = [{ pass_rate: 90 }, { pass_rate: 70 }, { pass_rate: 60 }];
+    expect(getTrendDirection(points)).toBe("down");
+  });
+
+  test("returns 'flat' when difference < 2", () => {
+    const points = [{ pass_rate: 80 }, { pass_rate: 81 }];
+    expect(getTrendDirection(points)).toBe("flat");
+  });
+
+  test("returns 'flat' for exact same values", () => {
+    const points = [{ pass_rate: 75 }, { pass_rate: 75 }];
+    expect(getTrendDirection(points)).toBe("flat");
+  });
+
+  test("skips null entries when computing direction", () => {
+    const points = [{ pass_rate: 50 }, null, { pass_rate: 80 }];
+    expect(getTrendDirection(points)).toBe("up");
+  });
+
+  test("skips entries with null pass_rate", () => {
+    const points = [
+      { pass_rate: 90 },
+      { pass_rate: null },
+      { pass_rate: 70 },
+    ];
+    expect(getTrendDirection(points)).toBe("down");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTrendArrow
+// ---------------------------------------------------------------------------
+describe("getTrendArrow", () => {
+  test("up → ↑ with trend-up class", () => {
+    expect(getTrendArrow("up")).toEqual({ arrow: "↑", cssClass: "trend-up" });
+  });
+
+  test("down → ↓ with trend-down class", () => {
+    expect(getTrendArrow("down")).toEqual({
+      arrow: "↓",
+      cssClass: "trend-down",
+    });
+  });
+
+  test("flat → → with trend-flat class", () => {
+    expect(getTrendArrow("flat")).toEqual({
+      arrow: "→",
+      cssClass: "trend-flat",
+    });
+  });
+
+  test("none → empty arrow with trend-none class", () => {
+    expect(getTrendArrow("none")).toEqual({
+      arrow: "",
+      cssClass: "trend-none",
+    });
+  });
+
+  test("unknown direction falls through to default", () => {
+    expect(getTrendArrow("sideways")).toEqual({
+      arrow: "",
+      cssClass: "trend-none",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSparkline
+// ---------------------------------------------------------------------------
+describe("createSparkline", () => {
+  const terms = [
+    { term_name: "Fall 2024", is_current: false },
+    { term_name: "Spring 2025", is_current: true },
+  ];
+  const points = [{ pass_rate: 80 }, { pass_rate: 65 }];
+
+  test("returns a canvas element", () => {
+    const canvas = createSparkline(points, terms, { threshold: 70 });
+    expect(canvas.tagName).toBe("CANVAS");
+  });
+
+  test("canvas has correct dimensions and class", () => {
+    const canvas = createSparkline(points, terms);
+    expect(canvas.width).toBe(90);
+    expect(canvas.height).toBe(28);
+    expect(canvas.className).toBe("plo-sparkline");
+  });
+
+  test("canvas has click-hint title", () => {
+    const canvas = createSparkline(points, terms);
+    expect(canvas.title).toBe("Click to view full trend chart");
+  });
+
+  test("returns empty canvas for null/empty points", () => {
+    const canvas1 = createSparkline(null, terms);
+    expect(canvas1.tagName).toBe("CANVAS");
+
+    const canvas2 = createSparkline([], terms);
+    expect(canvas2.tagName).toBe("CANVAS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTrendPanel
+// ---------------------------------------------------------------------------
+describe("createTrendPanel", () => {
+  const terms = [
+    { term_name: "Fall 2024", is_current: false },
+    { term_name: "Spring 2025", is_current: false },
+  ];
+  const points = [{ pass_rate: 80 }, { pass_rate: 90 }];
+
+  test("returns a div with plo-trend-panel class", () => {
+    const panel = createTrendPanel(points, terms, { threshold: 70 });
+    expect(panel.tagName).toBe("DIV");
+    expect(panel.className).toBe("plo-trend-panel");
+  });
+
+  test("contains a close button", () => {
+    const panel = createTrendPanel(points, terms);
+    const closeBtn = panel.querySelector(".plo-trend-panel-close");
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn.tagName).toBe("BUTTON");
+    expect(closeBtn.title).toBe("Close trend chart");
+  });
+
+  test("close button removes the panel from DOM", () => {
+    const parent = document.createElement("div");
+    const panel = createTrendPanel(points, terms);
+    parent.appendChild(panel);
+    expect(parent.children.length).toBe(1);
+
+    const closeBtn = panel.querySelector(".plo-trend-panel-close");
+    closeBtn.click();
+    expect(parent.children.length).toBe(0);
+  });
+
+  test("contains a canvas element", () => {
+    const panel = createTrendPanel(points, terms);
+    const canvas = panel.querySelector("canvas");
+    expect(canvas).not.toBeNull();
+  });
+
+  test("shows no-data message when points are empty", () => {
+    const panel = createTrendPanel([], terms);
+    expect(panel.textContent).toContain("No trend data available");
+  });
+
+  test("shows no-data message when points are null", () => {
+    const panel = createTrendPanel(null, terms);
+    expect(panel.textContent).toContain("No trend data available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PloTrend controller
+// ---------------------------------------------------------------------------
+describe("PloTrend controller", () => {
+  beforeEach(() => {
+    PloTrend.trendData = null;
+    global.fetch = jest.fn();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  describe("loadTrend", () => {
+    test("does nothing when programId is empty", async () => {
+      await PloTrend.loadTrend("");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("does nothing when programId is null", async () => {
+      await PloTrend.loadTrend(null);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("fetches trend data from correct URL", async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            terms: [],
+            plos: [],
+          }),
+      });
+
+      await PloTrend.loadTrend("prog-123");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/programs/prog-123/plo-dashboard/trend",
+        expect.objectContaining({
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        })
+      );
+    });
+
+    test("stores trend data on success", async () => {
+      const mockData = {
+        success: true,
+        terms: [{ term_name: "Fall 2024" }],
+        plos: [],
+      };
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      });
+
+      await PloTrend.loadTrend("prog-123");
+      expect(PloTrend.trendData).toEqual(mockData);
+    });
+
+    test("does not store data on failure response", async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: false }),
+      });
+
+      await PloTrend.loadTrend("prog-123");
+      expect(PloTrend.trendData).toBeNull();
+    });
+
+    test("handles fetch error gracefully", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+      global.fetch.mockRejectedValue(new Error("Network error"));
+
+      await PloTrend.loadTrend("prog-123");
+      expect(PloTrend.trendData).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    test("does not store data when resp.ok is false", async () => {
+      global.fetch.mockResolvedValue({ ok: false });
+
+      await PloTrend.loadTrend("prog-123");
+      expect(PloTrend.trendData).toBeNull();
+    });
+  });
+
+  describe("injectSparklines", () => {
+    test("does nothing when trendData is null", () => {
+      PloTrend.trendData = null;
+      PloTrend.injectSparklines(); // should not throw
+    });
+
+    test("does nothing when fewer than 2 terms", () => {
+      PloTrend.trendData = {
+        terms: [{ term_name: "Fall 2024" }],
+        plos: [],
+      };
+      PloTrend.injectSparklines(); // should not throw
+    });
+
+    test("does nothing when ploTreeContainer is missing", () => {
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024" },
+          { term_name: "Spring 2025" },
+        ],
+        plos: [],
+      };
+      // No DOM container
+      PloTrend.injectSparklines(); // should not throw
+    });
+
+    test("injects sparkline into PLO node", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta">
+                <span class="plo-assessment-badge">90%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "Test PLO",
+            trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const wrap = document.querySelector(".plo-sparkline-wrap");
+      expect(wrap).not.toBeNull();
+      expect(wrap.querySelector(".plo-sparkline")).not.toBeNull();
+    });
+
+    test("injects sparkline into CLO node", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+            <div data-clo-id="clo-1">
+              <div class="plo-tree-header">
+                <div class="plo-tree-meta">
+                  <span class="plo-assessment-badge">75%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "Test PLO",
+            trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+            clos: [
+              {
+                outcome_id: "clo-1",
+                clo_number: 1,
+                course_number: "CS101",
+                description: "Test CLO",
+                trend: [{ pass_rate: 70 }, { pass_rate: 85 }],
+              },
+            ],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const cloNode = document.querySelector('[data-clo-id="clo-1"]');
+      const wrap = cloNode.querySelector(".plo-sparkline-wrap");
+      expect(wrap).not.toBeNull();
+    });
+
+    test("removes existing sparklines before re-injecting", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <span class="plo-sparkline-wrap">old</span>
+          <div class="plo-trend-panel">old panel</div>
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "Test PLO",
+            trend: [{ pass_rate: 80 }, { pass_rate: 90 }],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      // Old sparkline-wrap with "old" text should be gone
+      const wraps = document.querySelectorAll(".plo-sparkline-wrap");
+      wraps.forEach((w) => {
+        expect(w.textContent).not.toBe("old");
+      });
+    });
+
+    test("skips PLO nodes with fewer than 2 trend points", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "Fall 2024", is_current: false },
+          { term_name: "Spring 2025", is_current: false },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "Short PLO",
+            trend: [{ pass_rate: 80 }], // only 1 data point
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      const wrap = document.querySelector(".plo-sparkline-wrap");
+      expect(wrap).toBeNull();
+    });
+  });
+
+  describe("_toggleTrendPanel", () => {
+    test("creates panel on first click, removes on second", () => {
+      document.body.innerHTML = `
+        <div id="testNode">
+          <div class="plo-tree-header"></div>
+        </div>
+      `;
+      const nodeEl = document.getElementById("testNode");
+      const terms = [
+        { term_name: "Fall 2024", is_current: false },
+        { term_name: "Spring 2025", is_current: false },
+      ];
+      const points = [{ pass_rate: 80 }, { pass_rate: 90 }];
+
+      // First call: creates panel
+      PloTrend._toggleTrendPanel(nodeEl, points, terms, {});
+      expect(nodeEl.querySelector(".plo-trend-panel")).not.toBeNull();
+
+      // Second call: removes panel
+      PloTrend._toggleTrendPanel(nodeEl, points, terms, {});
+      expect(nodeEl.querySelector(".plo-trend-panel")).toBeNull();
+    });
+  });
+});

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -232,6 +232,36 @@ describe("createSparkline", () => {
     const canvas2 = createSparkline([], terms);
     expect(canvas2.tagName).toBe("CANVAS");
   });
+
+  test("accepts selectedTermIndex option without error", () => {
+    const multiTerms = [
+      { term_name: "Fall 2023", is_current: false },
+      { term_name: "Spring 2024", is_current: false },
+      { term_name: "Fall 2024", is_current: false },
+      { term_name: "Spring 2025", is_current: true },
+    ];
+    const multiPoints = [
+      { pass_rate: 75 },
+      { pass_rate: 80 },
+      { pass_rate: 72 },
+      { pass_rate: 85 },
+    ];
+    // Select an older term (Fall 2024, index 2)
+    const canvas = createSparkline(multiPoints, multiTerms, {
+      threshold: 70,
+      selectedTermIndex: 2,
+    });
+    expect(canvas.tagName).toBe("CANVAS");
+    expect(canvas.className).toBe("plo-sparkline");
+  });
+
+  test("selectedTermIndex -1 uses default behavior", () => {
+    const canvas = createSparkline(points, terms, {
+      threshold: 70,
+      selectedTermIndex: -1,
+    });
+    expect(canvas.tagName).toBe("CANVAS");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -721,6 +751,7 @@ describe("createTrendPanel with CLO overlays", () => {
 describe("PloTrend controller", () => {
   beforeEach(() => {
     PloTrend.trendData = null;
+    PloTrend.selectedTermId = null;
     global.fetch = jest.fn();
     document.body.innerHTML = "";
   });
@@ -801,6 +832,29 @@ describe("PloTrend controller", () => {
 
       await PloTrend.loadTrend("prog-123");
       expect(PloTrend.trendData).toBeNull();
+    });
+
+    test("stores selectedTermId when provided", async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, terms: [], plos: [] }),
+      });
+
+      await PloTrend.loadTrend("prog-123", "term-42");
+      expect(PloTrend.selectedTermId).toBe("term-42");
+    });
+
+    test("preserves previous selectedTermId when not provided", async () => {
+      PloTrend.selectedTermId = "term-old";
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, terms: [], plos: [] }),
+      });
+
+      await PloTrend.loadTrend("prog-123");
+      expect(PloTrend.selectedTermId).toBe("term-old");
     });
   });
 
@@ -1099,6 +1153,58 @@ describe("PloTrend controller", () => {
 
       const slot = document.querySelector(".plo-summary-sparkline-slot");
       expect(slot.querySelector(".plo-sparkline")).toBeNull();
+    });
+
+    test("passes selectedTermIndex based on selectedTermId", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div class="plo-summary-bar">
+            <div class="plo-summary-row stat-pass">
+              <div class="plo-summary-sparkline-group">
+                <span class="plo-summary-sparkline-slot" data-plo-id="plo-1">
+                  <span class="plo-summary-sparkline-label">(1)</span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <div data-plo-id="plo-1">
+            <div class="plo-tree-header">
+              <div class="plo-tree-meta"></div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      PloTrend.selectedTermId = "term-2";
+      PloTrend.trendData = {
+        terms: [
+          { term_id: "term-1", term_name: "Fall 2024", is_current: false },
+          { term_id: "term-2", term_name: "Spring 2025", is_current: false },
+          { term_id: "term-3", term_name: "Fall 2025", is_current: true },
+        ],
+        plos: [
+          {
+            id: "plo-1",
+            plo_number: 1,
+            description: "PLO One",
+            trend: [
+              { pass_rate: 70 },
+              { pass_rate: 80 },
+              { pass_rate: 85 },
+            ],
+            clos: [],
+          },
+        ],
+      };
+
+      PloTrend.injectSparklines();
+
+      // Sparkline should still be injected
+      const slot = document.querySelector(".plo-summary-sparkline-slot");
+      expect(slot.querySelector(".plo-sparkline")).not.toBeNull();
+      // Tree node indicator also injected
+      const indicator = document.querySelector(".plo-trend-indicator");
+      expect(indicator).not.toBeNull();
     });
   });
 

--- a/tests/javascript/unit/plo_trend.test.js
+++ b/tests/javascript/unit/plo_trend.test.js
@@ -31,6 +31,16 @@ global.Chart = jest.fn().mockImplementation(() => ({
   chartArea: { left: 0, right: 100 },
 }));
 
+// Chart.getChart returns the instance attached to a canvas (used by _destroyCharts)
+const _chartInstances = new Map();
+const _origImpl = global.Chart.getMockImplementation();
+global.Chart.mockImplementation(function (canvas, ...args) {
+  const inst = _origImpl(canvas, ...args);
+  _chartInstances.set(canvas, inst);
+  return inst;
+});
+global.Chart.getChart = jest.fn((canvas) => _chartInstances.get(canvas) || null);
+
 // Execute requestAnimationFrame callbacks synchronously so Chart.js
 // rendering code is exercised for coverage.
 global.requestAnimationFrame = (cb) => cb();
@@ -1399,6 +1409,190 @@ describe("PloTrend controller", () => {
       // Second call: removes panel
       PloTrend._toggleTrendPanel(nodeEl, points, terms, {});
       expect(nodeEl.querySelector(".plo-trend-panel")).toBeNull();
+    });
+
+    test("destroys Chart.js instances before removing panel", () => {
+      document.body.innerHTML = `
+        <div id="testNode">
+          <div class="plo-tree-header"></div>
+        </div>
+      `;
+      const nodeEl = document.getElementById("testNode");
+      const terms = [
+        { term_name: "Fall 2024", is_current: false },
+        { term_name: "Spring 2025", is_current: false },
+      ];
+      const points = [{ pass_rate: 80 }, { pass_rate: 90 }];
+
+      // Create panel (which creates a Chart.js instance via requestAnimationFrame)
+      PloTrend._toggleTrendPanel(nodeEl, points, terms, {});
+      const panel = nodeEl.querySelector(".plo-trend-panel");
+      expect(panel).not.toBeNull();
+
+      // Get the canvas and its chart instance
+      const canvas = panel.querySelector("canvas");
+      expect(canvas).not.toBeNull();
+      const chartInst = Chart.getChart(canvas);
+
+      // Toggle off — should destroy chart before removing
+      PloTrend._toggleTrendPanel(nodeEl, points, terms, {});
+      expect(nodeEl.querySelector(".plo-trend-panel")).toBeNull();
+      if (chartInst) {
+        expect(chartInst.destroy).toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("keyboard accessibility", () => {
+    test("trend indicator responds to Enter key", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div data-plo-id="p1">
+            <div class="plo-tree-header">
+              <span class="plo-tree-meta">
+                <span class="plo-assessment-badge">badge</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      `;
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "F24", term_id: "t1", is_current: false },
+          { term_name: "S25", term_id: "t2", is_current: false },
+        ],
+        plos: [
+          {
+            id: "p1",
+            plo_number: 1,
+            description: "Test PLO",
+            trend: [{ pass_rate: 70 }, { pass_rate: 80 }],
+            clos: [],
+          },
+        ],
+      };
+      PloTrend.selectedTermId = null;
+      PloTrend.injectSparklines();
+
+      const indicator = document.querySelector(".plo-trend-indicator");
+      expect(indicator).not.toBeNull();
+      expect(indicator.getAttribute("tabindex")).toBe("0");
+      expect(indicator.getAttribute("role")).toBe("button");
+
+      // Simulate Enter keydown — should toggle panel
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+      });
+      indicator.dispatchEvent(event);
+
+      const panel = document.querySelector(".plo-trend-panel");
+      expect(panel).not.toBeNull();
+    });
+
+    test("summary sparkline responds to Space key", () => {
+      document.body.innerHTML = `
+        <div id="ploTreeContainer">
+          <div class="plo-summary-bar">
+            <div class="plo-summary-row">
+              <div class="plo-summary-sparkline-slot" data-plo-id="p1">
+                <span class="plo-summary-sparkline-label">PLO 1</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+      PloTrend.trendData = {
+        terms: [
+          { term_name: "F24", term_id: "t1", is_current: false },
+          { term_name: "S25", term_id: "t2", is_current: false },
+        ],
+        plos: [
+          {
+            id: "p1",
+            plo_number: 1,
+            description: "Test PLO",
+            trend: [{ pass_rate: 70 }, { pass_rate: 80 }],
+            clos: [],
+          },
+        ],
+      };
+      PloTrend.selectedTermId = null;
+      PloTrend.injectSparklines();
+
+      const canvas = document.querySelector(".plo-sparkline");
+      expect(canvas).not.toBeNull();
+      expect(canvas.getAttribute("tabindex")).toBe("0");
+      expect(canvas.getAttribute("role")).toBe("button");
+      expect(canvas.getAttribute("aria-label")).toContain("PLO-1");
+
+      // Simulate Space keydown — should toggle summary panel
+      const event = new KeyboardEvent("keydown", {
+        key: " ",
+        bubbles: true,
+      });
+      canvas.dispatchEvent(event);
+
+      const panel = document.querySelector(".plo-trend-panel");
+      expect(panel).not.toBeNull();
+    });
+  });
+
+  describe("loadTrend race guard", () => {
+    test("ignores stale response when a newer loadTrend is called", async () => {
+      let resolveFirst;
+      const firstFetch = new Promise((r) => {
+        resolveFirst = r;
+      });
+      let resolveSecond;
+      const secondFetch = new Promise((r) => {
+        resolveSecond = r;
+      });
+
+      let callCount = 0;
+      global.fetch = jest.fn(() => {
+        callCount++;
+        return callCount === 1 ? firstFetch : secondFetch;
+      });
+
+      document.body.innerHTML = '<div id="ploTreeContainer"></div>';
+      PloTrend.trendData = null;
+
+      // Start first load
+      const p1 = PloTrend.loadTrend("prog-1");
+      // Start second load before first completes (user switched programs)
+      const p2 = PloTrend.loadTrend("prog-2");
+
+      // Resolve second first (faster response)
+      resolveSecond({
+        ok: true,
+        json: async () => ({
+          success: true,
+          terms: [{ term_name: "T1" }, { term_name: "T2" }],
+          plos: [],
+        }),
+      });
+      await p2;
+
+      expect(PloTrend.trendData).not.toBeNull();
+      expect(PloTrend.trendData.success).toBe(true);
+
+      // Now resolve first (stale response) — should be ignored
+      const staleTrendData = PloTrend.trendData;
+      resolveFirst({
+        ok: true,
+        json: async () => ({
+          success: true,
+          terms: [{ term_name: "OLD" }],
+          plos: [{ id: "stale" }],
+        }),
+      });
+      await p1;
+
+      // trendData should still be from the second call, not overwritten
+      expect(PloTrend.trendData).toBe(staleTrendData);
+
+      delete global.fetch;
     });
   });
 });

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -904,7 +904,7 @@ class TestStaleSessionDetection:
         with self.app.test_request_context():
             from flask import session
 
-            from src.services.auth_service import AuthService, _read_db_generation
+            from src.services.auth_service import AuthService
 
             svc = AuthService()
 
@@ -979,7 +979,6 @@ class TestStaleSessionDetection:
     def test_write_and_read_db_generation(self, tmp_path):
         """write_db_generation creates a file that _read_db_generation can read."""
         from src.services.auth_service import (
-            DB_GENERATION_FILE,
             _read_db_generation,
             write_db_generation,
         )

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -884,3 +884,108 @@ def test_extract_request_value_from_args():
     with app.test_request_context(query_string="test_key=query_value"):
         value = _extract_request_value("test_key")
         assert value == "query_value"
+
+
+# ---------------------------------------------------------------------------
+#  Stale-session detection (database generation token)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSessionDetection:
+    """Verify that sessions are destroyed when the DB is re-seeded."""
+
+    def setup_method(self):
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.secret_key = "test-secret"
+
+    def test_stale_session_destroyed_when_generation_changes(self):
+        """A session whose _db_generation differs from disk is invalidated."""
+        with self.app.test_request_context():
+            from flask import session
+
+            from src.services.auth_service import AuthService, _read_db_generation
+
+            svc = AuthService()
+
+            # Pretend the session was created during generation "old-gen"
+            session["user_id"] = "u1"
+            session["email"] = "alice@example.com"
+            session["_db_generation"] = "old-gen"
+
+            # Patch the file read to return a different generation
+            with patch(
+                "src.services.auth_service._read_db_generation",
+                return_value="new-gen",
+            ):
+                with patch("data.session.manager.SessionService.destroy_session"):
+                    result = svc._get_session_user()
+
+            assert result is None, "Stale session should be rejected"
+
+    def test_session_valid_when_generation_matches(self):
+        """A session whose _db_generation matches disk is accepted."""
+        with self.app.test_request_context():
+            from flask import session
+
+            svc = AuthService()
+
+            session["user_id"] = "u1"
+            session["email"] = "alice@example.com"
+            session["_db_generation"] = "same-gen"
+
+            with patch(
+                "src.services.auth_service._read_db_generation",
+                return_value="same-gen",
+            ):
+                result = svc._get_session_user()
+
+            assert result is not None
+            assert result["email"] == "alice@example.com"
+
+    def test_no_generation_in_session_skips_check(self):
+        """Sessions without _db_generation are not invalidated (tests, old sessions)."""
+        with self.app.test_request_context():
+            from flask import session
+
+            svc = AuthService()
+
+            session["user_id"] = "u1"
+            session["email"] = "alice@example.com"
+            # No _db_generation key → guard is skipped
+
+            result = svc._get_session_user()
+            assert result is not None
+
+    def test_no_generation_file_skips_check(self):
+        """When the generation file doesn't exist, the check is a no-op."""
+        with self.app.test_request_context():
+            from flask import session
+
+            svc = AuthService()
+
+            session["user_id"] = "u1"
+            session["email"] = "alice@example.com"
+            session["_db_generation"] = "some-gen"
+
+            # File returns None (doesn't exist)
+            with patch(
+                "src.services.auth_service._read_db_generation", return_value=None
+            ):
+                result = svc._get_session_user()
+
+            assert result is not None
+
+    def test_write_and_read_db_generation(self, tmp_path):
+        """write_db_generation creates a file that _read_db_generation can read."""
+        from src.services.auth_service import (
+            DB_GENERATION_FILE,
+            _read_db_generation,
+            write_db_generation,
+        )
+
+        gen_file = tmp_path / ".db_generation"
+        with patch("src.services.auth_service.DB_GENERATION_FILE", gen_file):
+            token = write_db_generation()
+            assert token  # non-empty UUID string
+            assert _read_db_generation() == token

--- a/tests/unit/test_plo_trend.py
+++ b/tests/unit/test_plo_trend.py
@@ -14,7 +14,6 @@ Tests cover:
 from typing import Any, Dict, List
 from unittest.mock import patch
 
-
 import src.database.database_service as database_service
 import src.services.plo_service as plo_service
 from src.services.plo_service import (

--- a/tests/unit/test_plo_trend.py
+++ b/tests/unit/test_plo_trend.py
@@ -65,7 +65,7 @@ class TestBuildTermMetadata:
                 "end_date": "2023-05-15",
             },
         ]
-        with patch.object(plo_service, "get_term_status", return_value="COMPLETED"):
+        with patch.object(plo_service, "get_term_status", return_value="PASSED"):
             result = _build_term_metadata(terms)
         assert result[0]["is_current"] is False
 
@@ -74,7 +74,7 @@ class TestBuildTermMetadata:
         terms = [
             {"term_id": "tx", "term_name": "Test", "start_date": "", "end_date": ""}
         ]
-        with patch.object(plo_service, "get_term_status", return_value="COMPLETED"):
+        with patch.object(plo_service, "get_term_status", return_value="PASSED"):
             result = _build_term_metadata(terms)
         assert result[0]["term_id"] == "tx"
         assert result[0]["term_name"] == "Test"

--- a/tests/unit/test_plo_trend.py
+++ b/tests/unit/test_plo_trend.py
@@ -1,0 +1,500 @@
+"""Unit tests for plo_service PLO trend data helpers and get_plo_trend_data.
+
+Tests cover:
+- _build_term_metadata: term status resolution
+- _resolve_plo_clo_mapping: mapping → PLO↔CLO associations
+- _index_outcomes_by_clo_term: section outcome indexing
+- _aggregate_section_outcomes: arithmetic
+- _build_trend_point: null-handling
+- _extract_term_id: nested dict traversal
+- _build_clo_trends / _assemble_plo_trends: assembly
+- get_plo_trend_data: end-to-end with monkeypatched DB
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+
+import src.database.database_service as database_service
+import src.services.plo_service as plo_service
+from src.services.plo_service import (
+    _aggregate_section_outcomes,
+    _build_clo_trends,
+    _build_term_metadata,
+    _build_trend_point,
+    _extract_term_id,
+    _index_outcomes_by_clo_term,
+    get_plo_trend_data,
+)
+
+INST_DATA = {
+    "name": "Trend Test U",
+    "short_name": "TTU",
+    "admin_email": "admin@ttu.edu",
+    "created_by": "system",
+}
+
+
+# ---------------------------------------------------------------------------
+# _build_term_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTermMetadata:
+    def test_active_term_flagged(self):
+        terms = [
+            {
+                "id": "t1",
+                "name": "Fall 2023",
+                "start_date": "2023-08-01",
+                "end_date": "2023-12-15",
+            },
+        ]
+        with patch.object(plo_service, "get_term_status", return_value="ACTIVE"):
+            result = _build_term_metadata(terms)
+        assert len(result) == 1
+        assert result[0]["term_id"] == "t1"
+        assert result[0]["term_name"] == "Fall 2023"
+        assert result[0]["is_current"] is True
+
+    def test_past_term_not_current(self):
+        terms = [
+            {
+                "id": "t2",
+                "name": "Spring 2023",
+                "start_date": "2023-01-10",
+                "end_date": "2023-05-15",
+            },
+        ]
+        with patch.object(plo_service, "get_term_status", return_value="COMPLETED"):
+            result = _build_term_metadata(terms)
+        assert result[0]["is_current"] is False
+
+    def test_uses_term_id_fallback(self):
+        """Falls back to term_id key when id is missing."""
+        terms = [
+            {"term_id": "tx", "term_name": "Test", "start_date": "", "end_date": ""}
+        ]
+        with patch.object(plo_service, "get_term_status", return_value="COMPLETED"):
+            result = _build_term_metadata(terms)
+        assert result[0]["term_id"] == "tx"
+        assert result[0]["term_name"] == "Test"
+
+    def test_empty_list(self):
+        assert _build_term_metadata([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_section_outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateSectionOutcomes:
+    def test_basic_aggregation(self):
+        records = [
+            {"students_took": 20, "students_passed": 16},
+            {"students_took": 30, "students_passed": 24},
+        ]
+        result = _aggregate_section_outcomes(records)
+        assert result["students_took"] == 50
+        assert result["students_passed"] == 40
+        assert result["pass_rate"] == 80.0
+        assert result["section_count"] == 2
+        assert result["sections_with_data"] == 2
+
+    def test_ignores_zero_took(self):
+        records = [
+            {"students_took": 10, "students_passed": 8},
+            {"students_took": 0, "students_passed": 0},
+        ]
+        result = _aggregate_section_outcomes(records)
+        assert result["students_took"] == 10
+        assert result["students_passed"] == 8
+        assert result["sections_with_data"] == 1
+        assert result["section_count"] == 2
+
+    def test_ignores_none_values(self):
+        records = [
+            {"students_took": None, "students_passed": None},
+            {"students_took": 10, "students_passed": 7},
+        ]
+        result = _aggregate_section_outcomes(records)
+        assert result["students_took"] == 10
+        assert result["sections_with_data"] == 1
+
+    def test_empty_list_returns_none_rate(self):
+        result = _aggregate_section_outcomes([])
+        assert result["pass_rate"] is None
+        assert result["students_took"] == 0
+        assert result["section_count"] == 0
+        assert result["sections_with_data"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_trend_point
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTrendPoint:
+    def test_returns_none_for_empty(self):
+        assert _build_trend_point([], "t1") is None
+
+    def test_returns_point_with_term_id(self):
+        records = [{"students_took": 20, "students_passed": 18}]
+        result = _build_trend_point(records, "t-abc")
+        assert result is not None
+        assert result["term_id"] == "t-abc"
+        assert result["pass_rate"] == 90.0
+
+
+# ---------------------------------------------------------------------------
+# _extract_term_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTermId:
+    def test_direct_term_id(self):
+        assert _extract_term_id({"term_id": "t1"}) == "t1"
+
+    def test_nested_section_offering(self):
+        so = {"_section": {"_offering": {"term_id": "t2"}}}
+        assert _extract_term_id(so) == "t2"
+
+    def test_nested_offering_flat(self):
+        so = {"_offering": {"term_id": "t3"}}
+        assert _extract_term_id(so) == "t3"
+
+    def test_nested_term_object(self):
+        so = {"_section": {"_offering": {"_term": {"id": "t4"}}}}
+        assert _extract_term_id(so) == "t4"
+
+    def test_section_offering_keys(self):
+        so = {"section": {"offering": {"term_id": "t5"}}}
+        assert _extract_term_id(so) == "t5"
+
+    def test_returns_none_when_missing(self):
+        assert _extract_term_id({}) is None
+        assert _extract_term_id({"_section": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _index_outcomes_by_clo_term
+# ---------------------------------------------------------------------------
+
+
+class TestIndexOutcomesByCloTerm:
+    def test_indexes_correctly(self):
+        records = [
+            {"outcome_id": "c1", "term_id": "t1", "students_took": 10},
+            {"outcome_id": "c1", "term_id": "t2", "students_took": 20},
+            {"outcome_id": "c2", "term_id": "t1", "students_took": 30},
+        ]
+        idx = _index_outcomes_by_clo_term(records)
+        assert len(idx["c1"]["t1"]) == 1
+        assert len(idx["c1"]["t2"]) == 1
+        assert len(idx["c2"]["t1"]) == 1
+        assert "c2" not in idx or "t2" not in idx.get("c2", {})
+
+    def test_multiple_sections_same_clo_term(self):
+        records = [
+            {"outcome_id": "c1", "term_id": "t1", "students_took": 10},
+            {"outcome_id": "c1", "term_id": "t1", "students_took": 20},
+        ]
+        idx = _index_outcomes_by_clo_term(records)
+        assert len(idx["c1"]["t1"]) == 2
+
+    def test_skips_records_without_term_or_outcome(self):
+        records = [
+            {"outcome_id": "c1"},  # no term_id
+            {"term_id": "t1"},  # no outcome_id
+            {},  # nothing
+        ]
+        idx = _index_outcomes_by_clo_term(records)
+        assert idx == {}
+
+    def test_empty_input(self):
+        assert _index_outcomes_by_clo_term([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_clo_trends
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCloTrends:
+    def test_produces_trend_per_clo(self):
+        clo_ids = ["c1", "c2"]
+        clo_meta = {
+            "c1": {
+                "outcome_id": "c1",
+                "clo_number": "1",
+                "description": "CLO 1",
+                "course_number": "CS-101",
+            },
+            "c2": {
+                "outcome_id": "c2",
+                "clo_number": "2",
+                "description": "CLO 2",
+                "course_number": "CS-101",
+            },
+        }
+        by_clo_term = {
+            "c1": {
+                "t1": [{"students_took": 20, "students_passed": 16}],
+            },
+        }
+        term_meta = [
+            {"term_id": "t1", "term_name": "Fall 2023", "is_current": False},
+            {"term_id": "t2", "term_name": "Spring 2024", "is_current": False},
+        ]
+        result = _build_clo_trends(clo_ids, clo_meta, by_clo_term, term_meta)
+        assert len(result) == 2
+
+        # c1: has data in t1, null in t2
+        c1 = result[0]
+        assert c1["outcome_id"] == "c1"
+        assert c1["trend"][0] is not None
+        assert c1["trend"][0]["pass_rate"] == 80.0
+        assert c1["trend"][1] is None
+
+        # c2: no data anywhere
+        c2 = result[1]
+        assert c2["trend"][0] is None
+        assert c2["trend"][1] is None
+
+
+# ---------------------------------------------------------------------------
+# get_plo_trend_data (integration with DB, section outcomes stubbed)
+# ---------------------------------------------------------------------------
+
+
+def _wire(suffix: str, num_clos: int = 2):
+    """Build institution + program + 1 course + CLOs. Returns (inst_id, prog_id, [clo_ids])."""
+    inst_id = database_service.create_institution(
+        {**INST_DATA, "name": f"TTU {suffix}", "short_name": f"TTU{suffix}"}
+    )
+    prog_id = database_service.create_program(
+        {
+            "name": f"Program {suffix}",
+            "short_name": f"P{suffix}",
+            "institution_id": inst_id,
+        }
+    )
+    course_id = database_service.create_course(
+        {
+            "course_number": f"TRD-{suffix}",
+            "course_title": f"Trend test {suffix}",
+            "department": "TEST",
+            "institution_id": inst_id,
+        }
+    )
+    database_service.add_course_to_program(course_id, prog_id)
+    clo_ids: List[str] = []
+    for i in range(num_clos):
+        clo_ids.append(
+            database_service.create_course_outcome(
+                {
+                    "course_id": course_id,
+                    "clo_number": i + 1,
+                    "description": f"CLO {i+1} for {suffix}",
+                    "assessment_method": "exam",
+                    "active": True,
+                }
+            )
+        )
+    return inst_id, prog_id, clo_ids
+
+
+def _make_plo(prog_id: str, inst_id: str, n: int) -> str:
+    return database_service.create_program_outcome(
+        {
+            "program_id": prog_id,
+            "institution_id": inst_id,
+            "plo_number": n,
+            "description": f"PLO {n}",
+        }
+    )
+
+
+def _publish(prog_id: str, entries: list) -> str:
+    draft = database_service.get_or_create_plo_mapping_draft(prog_id)
+    mapping_id = draft["id"]
+    for plo_id, clo_id in entries:
+        database_service.add_plo_mapping_entry(mapping_id, plo_id, clo_id)
+    database_service.publish_plo_mapping(mapping_id, description="test")
+    return mapping_id
+
+
+def _make_terms(inst_id: str, count: int = 3) -> List[str]:
+    """Create *count* terms and return their ids."""
+    semesters = [
+        ("Fall 2023", "2023-08-01", "2023-12-15"),
+        ("Spring 2024", "2024-01-10", "2024-05-15"),
+        ("Fall 2024", "2024-08-01", "2024-12-15"),
+        ("Spring 2025", "2025-01-10", "2025-05-15"),
+    ]
+    term_ids = []
+    for i in range(min(count, len(semesters))):
+        name, start, end = semesters[i]
+        tid = database_service.create_term(
+            {
+                "institution_id": inst_id,
+                "term_name": name,
+                "start_date": start,
+                "end_date": end,
+            }
+        )
+        term_ids.append(tid)
+    return term_ids
+
+
+def _stub_section_outcomes(
+    monkeypatch,
+    records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Patch section outcome query with canned records."""
+    captured: List[Dict[str, Any]] = []
+
+    def _stub(**kw: Any) -> List[Dict[str, Any]]:
+        captured.append(dict(kw))
+        return records
+
+    monkeypatch.setattr(
+        plo_service.database_service,
+        "get_section_outcomes_by_criteria",
+        _stub,
+    )
+    return captured
+
+
+class TestGetPloTrendData:
+    def test_no_terms_returns_empty(self, monkeypatch):
+        """No terms in institution → empty result."""
+        inst_id, prog_id, _ = _wire("TRD_NT", num_clos=1)
+        # No terms created → get_all_terms returns []
+        result = get_plo_trend_data(prog_id, inst_id)
+        assert result["terms"] == []
+        assert result["plos"] == []
+        assert result["mapping_version"] is None
+
+    def test_no_mapping_returns_empty_plos(self, monkeypatch):
+        """Terms exist but no published mapping → empty trends on each PLO."""
+        inst_id, prog_id, _ = _wire("TRD_NM", num_clos=1)
+        _make_terms(inst_id, 2)
+        _make_plo(prog_id, inst_id, 1)
+
+        # Stub so no actual query happens
+        calls = _stub_section_outcomes(monkeypatch, [])
+
+        result = get_plo_trend_data(prog_id, inst_id)
+        assert len(result["terms"]) == 2
+        assert len(result["plos"]) == 1
+        # No mapping → no CLOs mapped → stub never called
+        assert len(calls) == 0
+
+    def test_trend_data_across_terms(self, monkeypatch):
+        """Correct pass rates per term with nulls for missing terms."""
+        inst_id, prog_id, clo_ids = _wire("TRD_OK", num_clos=1)
+        term_ids = _make_terms(inst_id, 3)
+        plo_id = _make_plo(prog_id, inst_id, 1)
+        _publish(prog_id, [(plo_id, clo_ids[0])])
+
+        # Simulate: data in term[0] and term[2], nothing in term[1]
+        _stub_section_outcomes(
+            monkeypatch,
+            [
+                {
+                    "outcome_id": clo_ids[0],
+                    "term_id": term_ids[0],
+                    "students_took": 20,
+                    "students_passed": 14,
+                },
+                {
+                    "outcome_id": clo_ids[0],
+                    "term_id": term_ids[2],
+                    "students_took": 20,
+                    "students_passed": 17,
+                },
+            ],
+        )
+
+        result = get_plo_trend_data(prog_id, inst_id)
+        assert result["mapping_version"] is not None
+        assert len(result["terms"]) == 3
+
+        plo = result["plos"][0]
+        assert plo["plo_number"] == 1
+
+        # Term 0: data, Term 1: null, Term 2: data
+        assert plo["trend"][0] is not None
+        assert plo["trend"][0]["pass_rate"] == 70.0
+        assert plo["trend"][1] is None
+        assert plo["trend"][2] is not None
+        assert plo["trend"][2]["pass_rate"] == 85.0
+
+        # CLO-level same shape
+        clo = plo["clos"][0]
+        assert clo["trend"][0]["pass_rate"] == 70.0
+        assert clo["trend"][1] is None
+        assert clo["trend"][2]["pass_rate"] == 85.0
+
+    def test_multiple_plos_independent_trends(self, monkeypatch):
+        """Each PLO aggregates only its own mapped CLOs."""
+        inst_id, prog_id, clo_ids = _wire("TRD_MP", num_clos=2)
+        term_ids = _make_terms(inst_id, 2)
+        plo1 = _make_plo(prog_id, inst_id, 1)
+        plo2 = _make_plo(prog_id, inst_id, 2)
+        _publish(prog_id, [(plo1, clo_ids[0]), (plo2, clo_ids[1])])
+
+        _stub_section_outcomes(
+            monkeypatch,
+            [
+                {
+                    "outcome_id": clo_ids[0],
+                    "term_id": term_ids[0],
+                    "students_took": 10,
+                    "students_passed": 8,
+                },
+                {
+                    "outcome_id": clo_ids[1],
+                    "term_id": term_ids[0],
+                    "students_took": 10,
+                    "students_passed": 5,
+                },
+            ],
+        )
+
+        result = get_plo_trend_data(prog_id, inst_id)
+        by_num = {p["plo_number"]: p for p in result["plos"]}
+
+        # PLO 1 → CLO 0: 80%
+        assert by_num[1]["trend"][0]["pass_rate"] == 80.0
+        # PLO 2 → CLO 1: 50%
+        assert by_num[2]["trend"][0]["pass_rate"] == 50.0
+
+    def test_term_ids_passed_to_query(self, monkeypatch):
+        """The section-outcome query receives correct term_ids filter."""
+        inst_id, prog_id, clo_ids = _wire("TRD_FI", num_clos=1)
+        term_ids = _make_terms(inst_id, 2)
+        plo_id = _make_plo(prog_id, inst_id, 1)
+        _publish(prog_id, [(plo_id, clo_ids[0])])
+
+        calls = _stub_section_outcomes(monkeypatch, [])
+        get_plo_trend_data(prog_id, inst_id)
+
+        assert len(calls) == 1
+        assert set(calls[0]["term_ids"]) == set(term_ids)
+        assert calls[0]["outcome_ids"] == [clo_ids[0]]
+
+    def test_plo_description_fallback_to_plo(self, monkeypatch):
+        """PLO description falls back to PLO record when no snapshot."""
+        inst_id, prog_id, clo_ids = _wire("TRD_SN", num_clos=1)
+        _make_terms(inst_id, 1)
+        plo_id = _make_plo(prog_id, inst_id, 1)
+        _publish(prog_id, [(plo_id, clo_ids[0])])
+
+        _stub_section_outcomes(monkeypatch, [])
+        result = get_plo_trend_data(prog_id, inst_id)
+
+        # No snapshot → uses PLO description
+        assert result["plos"][0]["description"] == "PLO 1"


### PR DESCRIPTION
## PLO Trending with Sparklines and Drill-Down Charts

Adds historical trend visualization to the PLO Dashboard, showing pass-rate trends across all terms with inline sparklines and expandable Chart.js drill-down charts.

### Backend
- get_plo_trend_data() service with 8 focused helpers (complexity <= C)
- Multi-term query support (term_ids param on get_section_outcomes_by_criteria)
- API endpoint: GET /api/programs/<id>/plo-dashboard/trend

### Frontend
- plo_trend.js with Chart.js 4.x CDN sparklines and drill-down panels
- Color-coded trend direction arrows
- Integrated into plo_dashboard.js via _loadTrendData()

### Seed Data
- 3 historical terms with improving pass rates (~70% -> ~75% -> ~83%)
- Term-aware override matching in seed_db.py

### Tests
- 27 unit tests across 7 classes
- All 10 quality gate checks pass